### PR TITLE
feat: introduce grouped experience cards and enhance tech badge styling

### DIFF
--- a/site/src/components/ExperienceCard.astro
+++ b/site/src/components/ExperienceCard.astro
@@ -1,6 +1,6 @@
 ---
 import { Icon } from 'astro-icon/components';
-import { TECH_ICON_MAP } from '../consts';
+import { getTechIcon } from '../consts';
 
 interface Props {
   id: string;
@@ -25,10 +25,6 @@ const {
   responsibilities = [],
   technologies,
 } = Astro.props;
-
-function getTechIcon(tech: string): string {
-  return TECH_ICON_MAP[tech] || 'tabler:code';
-}
 
 const maxCollapsedTech = 10;
 const hasMoreTech = technologies.length > maxCollapsedTech;
@@ -97,8 +93,8 @@ const hasMoreTech = technologies.length > maxCollapsedTech;
             <div class="flex flex-wrap gap-2 mt-3">
               {technologies.slice(0, maxCollapsedTech).map((tech) => (
                 <div class="tooltip" data-tip={tech}>
-                  <span class="badge badge-outline cursor-default">
-                    <Icon name={getTechIcon(tech)} class="w-5 h-5" />
+                  <span class="badge badge-outline cursor-default aspect-square p-1.5 bg-white">
+                    <Icon name={getTechIcon(tech)} class="w-5 h-5 text-black" />
                   </span>
                 </div>
               ))}
@@ -128,8 +124,8 @@ const hasMoreTech = technologies.length > maxCollapsedTech;
           {technologies.length > 0 && (
             <div class="flex flex-wrap gap-2">
               {technologies.map((tech) => (
-                <span class="badge badge-primary badge-outline gap-1.5">
-                  <Icon name={getTechIcon(tech)} class="w-4 h-4" />
+                <span class="badge badge-primary badge-outline gap-1.5 bg-white">
+                  <Icon name={getTechIcon(tech)} class="w-4 h-4 text-black" />
                   {tech}
                 </span>
               ))}

--- a/site/src/components/GroupedExperienceCard.astro
+++ b/site/src/components/GroupedExperienceCard.astro
@@ -1,0 +1,262 @@
+---
+import { Icon } from 'astro-icon/components';
+import { getTechIcon } from '../consts';
+
+interface Role {
+  id: string;
+  title: string;
+  period: string;
+  description: string;
+  responsibilities?: string[];
+  technologies: string[];
+}
+
+interface Props {
+  id: string;
+  title: string;
+  company: string;
+  companyUrl?: string;
+  location: string;
+  period: string;
+  roles: Role[];
+}
+
+const { id, title, company, companyUrl, location, period, roles } = Astro.props;
+
+const maxCollapsedTech = 8;
+---
+
+<div class="grouped-experience-card relative" data-id={id}>
+  <!-- Timeline dot -->
+  <div class="absolute left-[11px] top-8 w-6 h-6 rounded-full bg-base-100 border-2 border-primary hidden md:flex items-center justify-center z-10">
+    <div class="w-2 h-2 rounded-full bg-primary"></div>
+  </div>
+
+  <!-- Card -->
+  <div
+    id={`exp-${id}`}
+    class="card bg-base-200 transition-all hover:shadow-lg hover:border-primary/50 md:ml-14 scroll-mt-24 border border-base-300"
+  >
+    <div class="card-body p-5">
+      <!-- Header -->
+      <div class="flex items-start justify-between gap-4 mb-4">
+        <div class="flex-1 space-y-2">
+          <h3 class="card-title text-xl md:text-2xl">{title}</h3>
+          <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 text-sm">
+            {companyUrl ? (
+              <a
+                href={companyUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="flex items-center gap-1.5 font-medium text-primary hover:text-primary/80 transition-colors"
+              >
+                <Icon name="tabler:building" class="w-4 h-4" />
+                {company}
+              </a>
+            ) : (
+              <span class="flex items-center gap-1.5 font-medium text-primary">
+                <Icon name="tabler:building" class="w-4 h-4" />
+                {company}
+              </span>
+            )}
+            <span class="hidden sm:inline text-base-content/30">•</span>
+            <span class="flex items-center gap-1.5 text-base-content/70">
+              <Icon name="tabler:map-pin" class="w-4 h-4" />
+              {location}
+            </span>
+            <span class="hidden sm:inline text-base-content/30">•</span>
+            <span class="flex items-center gap-1.5 text-base-content/70">
+              <Icon name="tabler:calendar" class="w-4 h-4" />
+              {period}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Roles -->
+      <div class="space-y-4">
+        {roles.map((role, index) => {
+          const hasMoreTech = role.technologies.length > maxCollapsedTech;
+          const isLast = index === roles.length - 1;
+          return (
+            <div
+              class="role-card relative pl-4 border-l-2 border-base-300"
+              data-role-id={role.id}
+            >
+              <!-- Role connector dot -->
+              <div class="absolute -left-[5px] top-2 w-2 h-2 rounded-full bg-base-300"></div>
+
+              <!-- Role Header - clickable to toggle -->
+              <div
+                class="role-header cursor-pointer"
+                role="button"
+                tabindex="0"
+                aria-expanded="false"
+                id={`role-${role.id}`}
+              >
+                <div class="flex items-start justify-between gap-4">
+                  <div class="flex-1">
+                    <h4 class="font-semibold text-lg">{role.title}</h4>
+                    <span class="text-sm text-base-content/60 font-mono">{role.period}</span>
+                  </div>
+                  <button
+                    class="role-toggle btn btn-ghost btn-xs btn-square shrink-0"
+                    aria-label="Expand details"
+                  >
+                    <Icon name="tabler:chevron-down" class="w-4 h-4 transition-transform duration-200" />
+                  </button>
+                </div>
+              </div>
+
+              <!-- Collapsed content (description + limited tech) -->
+              <div class="role-collapsed grid grid-rows-[1fr] transition-all duration-200 ease-out mt-2">
+                <div class="overflow-hidden">
+                  <p class="text-sm text-base-content/70 leading-relaxed">{role.description}</p>
+                  {role.technologies.length > 0 && (
+                    <div class="flex flex-wrap gap-2 mt-3">
+                      {role.technologies.slice(0, maxCollapsedTech).map((tech) => (
+                        <div class="tooltip" data-tip={tech}>
+                          <span class="badge badge-outline cursor-default aspect-square p-1.5 bg-white">
+                            <Icon name={getTechIcon(tech)} class="w-5 h-5 text-black" />
+                          </span>
+                        </div>
+                      ))}
+                      {hasMoreTech && (
+                        <span class="badge badge-outline">
+                          +{role.technologies.length - maxCollapsedTech}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <!-- Expanded content (responsibilities + all tech) -->
+              <div class="role-expanded grid grid-rows-[0fr] transition-all duration-200 ease-out mt-0">
+                <div class="overflow-hidden">
+                  {role.responsibilities && role.responsibilities.length > 0 && (
+                    <ul class="space-y-1.5 text-sm mb-3">
+                      {role.responsibilities.map((item) => (
+                        <li class="flex gap-2 items-start">
+                          <span class="text-primary shrink-0 leading-snug">•</span>
+                          <span class="leading-snug">{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                  {role.technologies.length > 0 && (
+                    <div class="flex flex-wrap gap-2">
+                      {role.technologies.map((tech) => (
+                        <span class="badge badge-primary badge-outline gap-1.5 bg-white">
+                          <Icon name={getTechIcon(tech)} class="w-4 h-4 text-black" />
+                          {tech}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {!isLast && <div class="mt-4"></div>}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  // Store role controllers for hash-based expansion
+  const roleControllers: Map<string, { setExpanded: (expand: boolean) => void }> = new Map();
+  let controller: AbortController | null = null;
+  let initialized = false;
+
+  function initGroupedExperienceCards() {
+    // Abort previous listeners before re-initializing
+    if (controller) {
+      controller.abort();
+    }
+    controller = new AbortController();
+    roleControllers.clear();
+
+    document.querySelectorAll('.grouped-experience-card').forEach((card) => {
+      card.querySelectorAll('.role-card').forEach((roleCard) => {
+        const header = roleCard.querySelector('.role-header');
+        const toggle = roleCard.querySelector('.role-toggle');
+        const collapsed = roleCard.querySelector('.role-collapsed');
+        const expanded = roleCard.querySelector('.role-expanded');
+        const chevron = toggle?.querySelector('svg');
+        const roleId = roleCard.getAttribute('data-role-id');
+
+        let isExpanded = false;
+
+        function setExpanded(expand: boolean) {
+          isExpanded = expand;
+          header?.setAttribute('aria-expanded', String(expand));
+          toggle?.setAttribute('aria-label', expand ? 'Collapse details' : 'Expand details');
+
+          if (expand) {
+            collapsed?.classList.remove('grid-rows-[1fr]', 'mt-2');
+            collapsed?.classList.add('grid-rows-[0fr]', 'mt-0');
+            expanded?.classList.remove('grid-rows-[0fr]', 'mt-0');
+            expanded?.classList.add('grid-rows-[1fr]', 'mt-2');
+            chevron?.classList.add('rotate-180');
+          } else {
+            collapsed?.classList.remove('grid-rows-[0fr]', 'mt-0');
+            collapsed?.classList.add('grid-rows-[1fr]', 'mt-2');
+            expanded?.classList.remove('grid-rows-[1fr]', 'mt-2');
+            expanded?.classList.add('grid-rows-[0fr]', 'mt-0');
+            chevron?.classList.remove('rotate-180');
+          }
+        }
+
+        function handleToggle(e: Event) {
+          e.preventDefault();
+          setExpanded(!isExpanded);
+        }
+
+        const opts = { signal: controller!.signal };
+
+        header?.addEventListener('click', handleToggle, opts);
+        header?.addEventListener('keydown', (e) => {
+          if ((e as KeyboardEvent).key === 'Enter' || (e as KeyboardEvent).key === ' ') {
+            e.preventDefault();
+            handleToggle(e);
+          }
+        }, opts);
+
+        toggle?.addEventListener('click', (e) => {
+          e.stopPropagation();
+          handleToggle(e);
+        }, opts);
+
+        if (roleId) {
+          roleControllers.set(roleId, { setExpanded });
+        }
+      });
+    });
+
+    // Handle hash-based expansion
+    const handleHash = () => {
+      const hash = window.location.hash.slice(1);
+      const roleController = roleControllers.get(hash);
+      if (roleController) {
+        roleController.setExpanded(true);
+        setTimeout(() => {
+          document.getElementById(`role-${hash}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }, 100);
+      }
+    };
+
+    handleHash();
+    window.addEventListener('hashchange', handleHash, { signal: controller.signal });
+  }
+
+  initGroupedExperienceCards();
+
+  if (!initialized) {
+    initialized = true;
+    document.addEventListener('astro:after-swap', initGroupedExperienceCards);
+  }
+</script>

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -74,4 +74,40 @@ export const TECH_ICON_MAP: Record<string, string> = {
   Grunt: 'logos:grunt',
   Terraform: 'logos:terraform-icon',
   CSS: 'logos:css-3',
+  // Cloudflare stack
+  Golang: 'logos:go',
+  Kubernetes: 'logos:kubernetes',
+  Kafka: 'logos:kafka-icon',
+  Prometheus: 'logos:prometheus',
+  VictoriaMetrics: 'tabler:chart-line',
+  Clickhouse: 'tabler:database',
+  'Cloudflare Workers': 'logos:cloudflare-workers-icon',
+  'C++': 'logos:c-plusplus',
+  Rust: 'logos:rust',
+  Protobuf: 'tabler:file-code',
+  "Cap'n Proto": 'tabler:message-code',
+  Ceph: 'tabler:server',
+  Buf: 'tabler:package',
+  Quicksilver: 'tabler:bolt',
+  Parquet: 'tabler:file-type-doc',
+  R2: 'logos:cloudflare-icon',
+  'IVF+PQ': 'tabler:vector',
+  // Skills section
+  'C/C++': 'logos:c',
+  Java: 'logos:java',
+  Ruby: 'logos:ruby',
+  'JavaScript/ES6': 'logos:javascript',
+  Lua: 'logos:lua',
+  Haskell: 'logos:haskell-icon',
+  Express: 'logos:express',
+  MongoDB: 'logos:mongodb-icon',
+  AWS: 'logos:aws',
+  'PCB Design': 'tabler:cpu',
+  'Raspberry Pi': 'logos:raspberry-pi',
+  Arduino: 'logos:arduino',
+  Modbus: 'tabler:plug-connected',
 };
+
+export function getTechIcon(tech: string): string {
+  return TECH_ICON_MAP[tech] || 'tabler:code';
+}

--- a/site/src/pages/cv.astro
+++ b/site/src/pages/cv.astro
@@ -3,8 +3,96 @@ import { Icon } from 'astro-icon/components';
 import BaseHead from '../components/BaseHead.astro';
 import ExperienceCard from '../components/ExperienceCard.astro';
 import Footer from '../components/Footer.astro';
+import GroupedExperienceCard from '../components/GroupedExperienceCard.astro';
 import Header from '../components/Header.astro';
-import { SITE_TITLE } from '../consts';
+import { getTechIcon, SITE_TITLE } from '../consts';
+
+const cloudflare = {
+  id: 'cloudflare',
+  title: 'Senior Systems Engineer',
+  company: 'Cloudflare',
+  companyUrl: 'https://cloudflare.com',
+  location: 'Austin, TX',
+  period: 'Dec 2019 – Aug 2024',
+  roles: [
+    {
+      id: 'cloudflare-workers-ai',
+      title: 'Workers AI / Vectorize',
+      period: 'May 2023 – Aug 2024',
+      description:
+        "Cloudflare's edge-native, serverless vector database powering AI products and embeddings workflows.",
+      responsibilities: [
+        'Designed and implemented a custom vector storage format optimized for document-store workloads using IVF+PQ search patterns, improving query efficiency at the edge',
+        'Built a custom metadata storage engine supporting low-latency index lookups on distributed edge nodes for real-time retrieval workloads',
+        'Developed a dynamic re-indexer that monitored index properties and load metrics to automatically re-compute and version indices in real time, ensuring sustained query performance',
+      ],
+      technologies: [
+        'Golang',
+        'Rust',
+        'TypeScript',
+        'Kubernetes',
+        'Docker',
+        'IVF+PQ',
+        'Parquet',
+        'R2',
+        'Cloudflare Workers',
+      ],
+    },
+    {
+      id: 'cloudflare-workers-core',
+      title: 'Workers Core Platform',
+      period: 'Mar 2022 – May 2023',
+      description:
+        'Managed the build pipeline and configuration systems for Cloudflare Workers.',
+      responsibilities: [
+        'Built and launched Workers for Platforms, extending the C++ V8 runtime to support dynamic resource allocation and runtime dispatch, enabling multi-tenant execution at scale',
+        "Implemented privileged binding support via Cap'n Proto RPC, enabling dynamic injection of bindings for trusted accounts and improving runtime security isolation",
+        'Expanded Workers edge storage from Quicksilver to a tiered system incorporating Ceph and external backends, improving scalability and data durability',
+      ],
+      technologies: [
+        'Golang',
+        'C++',
+        'Kubernetes',
+        'Docker',
+        'Buf',
+        'Protobuf',
+        "Cap'n Proto",
+        'Kafka',
+        'Prometheus',
+        'Clickhouse',
+        'Ceph',
+        'Quicksilver',
+        'PostgreSQL',
+        'Cloudflare Workers',
+      ],
+    },
+    {
+      id: 'cloudflare-internal-tools',
+      title: 'Internal Tools Team',
+      period: 'Dec 2019 – Mar 2022',
+      description:
+        'Cross-team abstractions used across Cloudflare, serving both internal developers and external product surfaces.',
+      responsibilities: [
+        "Architected and launched Cloudflare's customer alerting platform, enabling service-based alert dispatch with enriched context via VictoriaMetrics and Clickhouse. Implemented multi-window SLO burn-rate anomaly detection to improve incident responsiveness",
+        "Operated and optimized Cloudflare's Kafka-backed internal messaging system powering 300+ producers/consumers across 15 brokers, processing over 1T messages per day",
+        "Spearheaded the Search Engine Crawl Hints initiative with Microsoft and Yandex, integrating with Cloudflare's cache invalidation stack to reduce redundant crawls and network load",
+      ],
+      technologies: [
+        'Golang',
+        'Kubernetes',
+        'Docker',
+        'Redis',
+        'Kafka',
+        'Prometheus',
+        'VictoriaMetrics',
+        'Clickhouse',
+        'PostgreSQL',
+        'TypeScript',
+        'Cloudflare Workers',
+      ],
+    },
+  ],
+};
 
 const experience = [
   {
@@ -174,6 +262,15 @@ const skills = {
           />
 
           <div class="space-y-6">
+            <GroupedExperienceCard
+              id={cloudflare.id}
+              title={cloudflare.title}
+              company={cloudflare.company}
+              companyUrl={cloudflare.companyUrl}
+              location={cloudflare.location}
+              period={cloudflare.period}
+              roles={cloudflare.roles}
+            />
             {
               experience.map((job) => (
                 <ExperienceCard
@@ -266,7 +363,10 @@ const skills = {
                   <h3 class="card-title text-lg">{category}</h3>
                   <div class="flex flex-wrap gap-2">
                     {skillList.map((skill) => (
-                      <span class="badge badge-primary">{skill}</span>
+                      <span class="badge badge-primary badge-outline gap-1.5 bg-white">
+                        <Icon name={getTechIcon(skill)} class="w-4 h-4 text-black" />
+                        {skill}
+                      </span>
                     ))}
                   </div>
                 </div>


### PR DESCRIPTION
Implement a new component to better showcase hierarchical work experience with multiple roles at the same company. Added visual consistency across all technology badges with icons and improved accessibility.

- Add GroupedExperienceCard component with expandable role sections and smooth animations
- Enhance technology badges with consistent white backgrounds and black icons
- Expand tech icon mapping to support broader range of technologies including Cloudflare stack
- Integrate detailed Cloudflare experience with three distinct role periods
- Apply unified badge styling to skills section for visual consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced grouped experience cards with per-role expand/collapse, deep-link (hash) support, and auto-scroll to expanded roles
  * Keyboard and accessibility improvements for toggling role details

* **Style**
  * Expanded tech icon library and added icons to skill badges
  * Redesigned technology badges as square, white-background facets with dark icons/text

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->