### PR TITLE
docs: enhance documentation with comprehensive project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,88 @@
-# HQ
+<p align="center">
+  <img src="site/src/assets/logos/diz-rocks-avatar.svg" alt="diz.rocks logo" width="120" height="120" />
+</p>
 
-Personal website and infrastructure monorepo.
+<h1 align="center">HQ</h1>
 
-## Structure
+<p align="center">
+  <em>Command center for all things diz.rocks</em>
+</p>
 
-```text
+<p align="center">
+  <a href="https://github.com/ndisidore/hq/actions/workflows/ci.yml">
+    <img src="https://github.com/ndisidore/hq/actions/workflows/ci.yml/badge.svg" alt="CI Status" />
+  </a>
+  <img src="https://img.shields.io/badge/Astro-5-BC52EE?logo=astro&logoColor=white" alt="Astro 5" />
+  <img src="https://img.shields.io/badge/Tailwind-4-06B6D4?logo=tailwindcss&logoColor=white" alt="Tailwind CSS 4" />
+  <img src="https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white" alt="Cloudflare Workers" />
+  <img src="https://img.shields.io/badge/Terraform-soon%E2%84%A2-844FBA?logo=terraform&logoColor=white" alt="Terraform" />
+</p>
+
+---
+
+## What is this?
+
+This is my personal monorepo—the nerve center where my website lives and my infrastructure (eventually) gets wrangled. Think of it as a digital treehouse, but with more YAML and fewer splinters.
+
+## The Map
+
+```
 .
-├── site/       # Astro blog/personal website (Cloudflare Workers)
-└── infra/      # Terraform infrastructure (placeholder)
+├── site/    # The website. Where words become HTML and dreams become CSS.
+├── infra/   # Infrastructure as Code. Currently just vibes and a .gitkeep.
+└── .github/ # CI workflows that yell at me when I mess up.
 ```
 
-## Site
+| Directory | What's Inside | Status |
+|-----------|---------------|--------|
+| [`site/`](./site/) | Astro-powered blog & personal site | Live & kicking |
+| [`infra/`](./infra/) | Terraform infrastructure | Placeholder (but make it professional) |
 
-The website is built with [Astro](https://astro.build) and deployed to Cloudflare Workers.
-
-### Getting Started
+## Quick Start
 
 ```bash
+# Clone the HQ
+git clone https://github.com/ndisidore/hq.git
+cd hq
+
+# Enter the site dimension
 cd site
 npm install
-npm run dev      # Start dev server at localhost:4321
+npm run dev
+
+# Marvel at http://localhost:4321
 ```
 
-### Commands
+## Tech Stack
 
-All commands are run from the `site/` directory:
+| Layer | Tools |
+|-------|-------|
+| **Frontend** | [Astro 5](https://astro.build), [Tailwind CSS v4](https://tailwindcss.com), [DaisyUI](https://daisyui.com) |
+| **Content** | Markdown/MDX with Zod-validated frontmatter |
+| **Hosting** | [Cloudflare Workers](https://workers.cloudflare.com) |
+| **Linting** | [Biome](https://biomejs.dev), markdownlint, [Harper](https://github.com/Automattic/harper) |
+| **Tooling** | [mise](https://mise.jdx.dev) for version management |
+| **Infra** | Terraform (coming to a `terraform apply` near you) |
 
-| Command           | Action                                       |
-| :---------------- | :------------------------------------------- |
-| `npm install`     | Install dependencies                         |
-| `npm run dev`     | Start local dev server at `localhost:4321`   |
-| `npm run build`   | Build production site to `./dist/`           |
-| `npm run preview` | Build and preview locally via Wrangler       |
-| `npm run deploy`  | Build and deploy to Cloudflare Workers       |
-| `npm run lint`    | Run Biome linter                             |
+## CI Pipeline
 
-### Features
+Every push and PR triggers the gauntlet:
 
-- Astro 5 with static site generation
-- Tailwind CSS v4 + DaisyUI theming
-- Markdown/MDX blog content
-- RSS feed and sitemap
-- Light/dark theme toggle
+1. **Biome** - Checks code style (it has opinions, and they're usually right)
+2. **markdownlint** - Ensures blog posts aren't chaos
+3. **Harper** - Grammar cop for your prose
 
-## Infrastructure
+## Deep Dives
 
-The `infra/` directory is a placeholder for future Terraform infrastructure code.
+- **[`site/README.md`](./site/README.md)** - Everything about the website: architecture, theming, content system, and more
+- **[`infra/README.md`](./infra/README.md)** - The infrastructure roadmap (spoiler: it's mostly dreams right now)
 
-## Tool Versions
+## License
 
-Tool versions are managed via [mise](https://mise.jdx.dev/). Run `mise install` from the `site/` directory to install Node.js and other required tools.
+Do whatever you want with the code. The content (blog posts, etc.) is mine though—please don't pretend you wrote my ramblings.
+
+---
+
+<p align="center">
+  <sub>Built with caffeine, mass amounts of Chipotle, and mass amounts of mass amounts.</sub>
+</p>

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,55 @@
+# Infrastructure
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Terraform-Planned-844FBA?logo=terraform&logoColor=white" alt="Terraform Planned" />
+  <img src="https://img.shields.io/badge/Status-Vibes%20Only-yellow" alt="Status: Vibes Only" />
+</p>
+
+---
+
+## Current State
+
+```
+infra/
+└── .gitkeep    # The loneliest file in the repo
+```
+
+This directory is a placeholder for future Infrastructure as Code. It exists as a promise to my future self that one day, cloud resources will be properly managed here.
+
+## The Vision
+
+When this directory grows up, it wants to be:
+
+- **Terraform modules** for cloud infrastructure
+- **State management** (probably remote, because we're not savages)
+- **Environment configs** for staging/production
+- **CI/CD integration** for safe `terraform apply`
+
+## Potential Scope
+
+| Resource | Provider | Priority |
+|----------|----------|----------|
+| DNS records | Cloudflare | Eventually |
+| Secrets management | TBD | Someday |
+| Monitoring/alerts | TBD | When things break |
+| Backups | TBD | After data loss teaches a lesson |
+
+## Why Not Now?
+
+The website runs on Cloudflare Workers via Wrangler, which handles deployment without Terraform. Additional infrastructure will be added here as needs arise (and as motivation permits).
+
+## Contributing
+
+If you're reading this and thinking "I should add Terraform here," please consider:
+
+1. Do I actually need this?
+2. Is YAML the answer? (It's rarely the answer)
+3. Will I maintain this?
+
+If you answered "yes" to all three, go for it. Otherwise, the `.gitkeep` is doing its job just fine.
+
+---
+
+<p align="center">
+  <sub>Part of the <a href="../README.md">HQ monorepo</a></sub>
+</p>

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -38,21 +38,26 @@ Tags have dedicated filter pages at `/tags/[tag]`. Tag utilities are in `src/uti
 
 ### Theming
 
-Two DaisyUI themes: "light" (default) and "dracula" (dark). Theme persistence uses localStorage with system preference fallback. The `ThemeToggle.astro` component handles switching. FOUC is prevented by an inline script in `BaseHead.astro` that sets the theme before render.
+Extensive theming support via DaisyUI. Theme persistence uses localStorage with system preference fallback. The `ThemeToggle.astro` component handles switching. FOUC is prevented by an inline script in `BaseHead.astro` that sets the theme before render.
 
 ### Icons
 
-Icons use [Iconify](https://iconify.design/) via `astro-icon` with the Tabler icon set:
+Icons use [Iconify](https://iconify.design/) via `astro-icon`. Three icon sets are installed:
+
+- `tabler:` - UI icons ([browse](https://icon-sets.iconify.design/tabler/))
+- `simple-icons:` - Brand icons ([browse](https://icon-sets.iconify.design/simple-icons/))
+- `logos:` - Tech/brand logos ([browse](https://icon-sets.iconify.design/logos/))
 
 ```astro
 ---
 import { Icon } from 'astro-icon/components';
 ---
 <Icon name="tabler:calendar" class="h-4 w-4" />
-<Icon name="tabler:brand-github" class="w-5 h-5" />
+<Icon name="simple-icons:github" class="w-5 h-5" />
+<Icon name="logos:astro-icon" class="w-6 h-6" />
 ```
 
-Browse icons at https://icon-sets.iconify.design/tabler/. To add other icon sets, install `@iconify-json/<set-name>`.
+To add other icon sets, install `@iconify-json/<set-name>`.
 
 ### Key Files
 

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,171 @@
+<p align="center">
+  <img src="src/assets/logos/diz-rocks-light.svg" alt="diz.rocks" width="200" />
+</p>
+
+<p align="center">
+  <strong>The Website</strong><br/>
+  <em>A static blog and personal site, lovingly crafted with Astro</em>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Astro-5-BC52EE?logo=astro&logoColor=white" alt="Astro 5" />
+  <img src="https://img.shields.io/badge/Tailwind-4-06B6D4?logo=tailwindcss&logoColor=white" alt="Tailwind CSS 4" />
+  <img src="https://img.shields.io/badge/DaisyUI-5-1AD1A5?logo=daisyui&logoColor=white" alt="DaisyUI 5" />
+  <img src="https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white" alt="Cloudflare Workers" />
+</p>
+
+---
+
+## Commands
+
+All commands run from this directory (`site/`):
+
+| Command | Action |
+|---------|--------|
+| `npm run dev` | Start dev server at `localhost:4321` |
+| `npm run build` | Build production site to `./dist/` |
+| `npm run preview` | Build and preview locally via Wrangler |
+| `npm run deploy` | Build and deploy to Cloudflare Workers |
+| `npm run lint` | Run Biome linter |
+| `npm run lint:fix` | Auto-fix lint issues |
+| `npm run format` | Format code with Biome |
+| `npm run cf-typegen` | Generate Cloudflare Worker types |
+
+### Tool Versions (mise)
+
+This project uses [mise](https://mise.jdx.dev) to manage tool versions. See [`mise.toml`](./mise.toml) for the full configuration.
+
+```bash
+# Install all required tools
+mise install
+
+# Or trust and install in one go
+mise trust && mise install
+```
+
+**Managed tools:**
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| Node.js | LTS | Runtime |
+| markdownlint-cli | latest | Markdown linting |
+| harper-cli | latest | Grammar checking |
+| pandoc | latest | Document conversion (for Harper preprocessing) |
+
+---
+
+## Architecture
+
+### Project Structure
+
+```
+src/
+├── assets/         # Images, logos, static assets
+├── components/     # Astro/UI components
+├── content/        # Blog posts (Markdown/MDX)
+│   └── blog/       # Blog content collection
+├── layouts/        # Page layouts
+├── pages/          # File-based routing
+├── styles/         # Global CSS
+└── utils/          # Helper functions
+
+public/             # Static files (copied as-is)
+scripts/            # Build/CI scripts
+```
+
+### Content System
+
+Blog posts live in `src/content/blog/` as Markdown or MDX files. The content schema is defined in `src/content.config.ts` with Zod validation.
+
+**Required frontmatter:**
+```yaml
+---
+title: "Your Post Title"
+description: "A compelling description"
+pubDate: 2025-01-06
+tags: ["astro", "webdev"]
+---
+```
+
+**Optional fields:**
+- `updatedDate` - When the post was last updated
+- `heroImage` - Featured image path
+
+### Routing
+
+File-based routing in `src/pages/`:
+
+| Route | File | Description |
+|-------|------|-------------|
+| `/` | `index.astro` | Home page |
+| `/blog` | `blog/index.astro` | Blog listing |
+| `/blog/[slug]` | `blog/[...slug].astro` | Individual blog posts |
+| `/tags/[tag]` | `tags/[...tag].astro` | Posts filtered by tag |
+| `/rss.xml` | `rss.xml.js` | RSS feed |
+
+All routes are statically generated via `getStaticPaths()`.
+
+### Theming
+
+The site supports extensive theming via [DaisyUI](https://daisyui.com/docs/themes/). Theme persistence uses localStorage with system preference fallback. The `ThemeToggle.astro` component handles switching, and an inline script in `BaseHead.astro` prevents FOUC (Flash of Unstyled Content).
+
+### Icons
+
+Icons use [Iconify](https://iconify.design/) via `astro-icon`. Three icon sets are installed:
+
+| Set | Prefix | Browse | Use Case |
+|-----|--------|--------|----------|
+| [Tabler](https://icon-sets.iconify.design/tabler/) | `tabler:` | [Browse](https://icon-sets.iconify.design/tabler/) | UI icons |
+| [Simple Icons](https://icon-sets.iconify.design/simple-icons/) | `simple-icons:` | [Browse](https://icon-sets.iconify.design/simple-icons/) | Brand icons |
+| [Logos](https://icon-sets.iconify.design/logos/) | `logos:` | [Browse](https://icon-sets.iconify.design/logos/) | Tech/brand logos |
+
+```astro
+---
+import { Icon } from 'astro-icon/components';
+---
+<Icon name="tabler:calendar" class="h-4 w-4" />
+<Icon name="simple-icons:github" class="w-5 h-5" />
+<Icon name="logos:astro-icon" class="w-6 h-6" />
+```
+
+---
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/consts.ts` | Site metadata (title, author, social links) |
+| `src/styles/app.css` | Global styles and Tailwind directives |
+| `src/layouts/BlogPost.astro` | Blog post layout with TOC, metadata, navigation |
+| `astro.config.mjs` | Astro configuration (site URL, integrations, Shiki) |
+| `wrangler.jsonc` | Cloudflare Workers configuration |
+| `biome.json` | Biome linter/formatter configuration |
+
+---
+
+## Code Style
+
+[Biome](https://biomejs.dev) handles linting and formatting:
+
+- Single quotes
+- Always semicolons
+- 2-space indentation
+- Tailwind CSS directives enabled
+
+Markdown files in `src/content/blog/` are additionally linted with:
+- **markdownlint** - Structural consistency
+- **Harper** - Grammar checking (via pandoc preprocessing)
+
+---
+
+## Deployment
+
+The site deploys to Cloudflare Workers on merge to `main` (manual deploy via `npm run deploy`).
+
+Build output goes to `./dist/` which Wrangler packages and deploys.
+
+---
+
+<p align="center">
+  <sub>Part of the <a href="../README.md">HQ monorepo</a></sub>
+</p>


### PR DESCRIPTION
This update transforms the repository documentation from minimal setup instructions to a complete project guide that showcases the monorepo architecture and personal branding.

• Add centered logo and branding with tech stack badges to main README
• Create detailed site documentation covering architecture, theming, and content system
• Add infrastructure directory documentation outlining future Terraform plans
• Include comprehensive tool version management and CI pipeline details
• Enhance project structure explanation with routing and deployment information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Replaced main README with a new HTML-styled, section-driven layout (hero, The Map, Quick Start, Tech Stack, Deep Dives, License) and updated prose
  * Added CI badge blocks and expanded CI pipeline documentation and quick-start commands
  * Added an infra README outlining infrastructure plans and priorities
  * Added a comprehensive site README covering setup, content system, theming, deployment, and architecture
  * Updated theming and icon guidance for the site documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->