### PR TITLE
feat: enhance cv page with presentation links and improved education layout

### DIFF
--- a/site/src/components/Breadcrumb.astro
+++ b/site/src/components/Breadcrumb.astro
@@ -1,7 +1,10 @@
 ---
+import { Icon } from 'astro-icon/components';
+
 interface BreadcrumbItem {
   label: string;
   href?: string;
+  icon?: string;
 }
 
 interface Props {
@@ -17,9 +20,15 @@ const { items } = Astro.props;
       items.map((item, index) => (
         <li>
           {item.href && index < items.length - 1 ? (
-            <a href={item.href}>{item.label}</a>
+            <a href={item.href} class="flex items-center gap-1">
+              {item.icon && <Icon name={item.icon} class="h-4 w-4 shrink-0" />}
+              {item.label}
+            </a>
           ) : (
-            <span class="truncate max-w-[200px]">{item.label}</span>
+            <span class="truncate max-w-[200px] flex items-center gap-1">
+              {item.icon && <Icon name={item.icon} class="h-4 w-4 shrink-0" />}
+              {item.label}
+            </span>
           )}
         </li>
       ))

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -5,6 +5,13 @@ import avatar from '../assets/logos/diz-rocks-avatar.svg';
 import { SITE_TITLE, SOCIAL_LINKS } from '../consts';
 import HeaderLink from './HeaderLink.astro';
 import ThemeToggle from './ThemeToggle.astro';
+
+const navItems = [
+  { href: '/', label: 'Home', icon: 'tabler:home' },
+  { href: '/blog', label: 'Blog', icon: 'tabler:news' },
+  { href: '/cv', label: 'CV', icon: 'tabler:user-code' },
+  { href: '/about', label: 'About', icon: 'tabler:user-square' },
+];
 ---
 
 <header class="navbar bg-base-100 shadow-sm sticky top-0 z-50">
@@ -17,10 +24,16 @@ import ThemeToggle from './ThemeToggle.astro';
         tabindex="0"
         class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52"
       >
-        <li><a href="/">Home</a></li>
-        <li><a href="/blog">Blog</a></li>
-        <li><a href="/cv">CV</a></li>
-        <li><a href="/about">About</a></li>
+        {
+          navItems.map((item) => (
+            <li>
+              <a href={item.href} class="flex items-center gap-2">
+                <Icon name={item.icon} class="h-4 w-4" />
+                {item.label}
+              </a>
+            </li>
+          ))
+        }
       </ul>
     </div>
     <a href="/" class="btn btn-ghost text-xl gap-2">
@@ -30,11 +43,16 @@ import ThemeToggle from './ThemeToggle.astro';
   </div>
 
   <div class="navbar-center hidden lg:flex">
-    <ul class="menu menu-horizontal px-1">
-      <li><HeaderLink href="/">Home</HeaderLink></li>
-      <li><HeaderLink href="/blog">Blog</HeaderLink></li>
-      <li><HeaderLink href="/cv">CV</HeaderLink></li>
-      <li><HeaderLink href="/about">About</HeaderLink></li>
+    <ul class="menu menu-horizontal gap-2">
+      {
+        navItems.map((item) => (
+          <li>
+            <HeaderLink href={item.href} icon={item.icon}>
+              {item.label}
+            </HeaderLink>
+          </li>
+        ))
+      }
     </ul>
   </div>
 

--- a/site/src/components/HeaderLink.astro
+++ b/site/src/components/HeaderLink.astro
@@ -1,9 +1,12 @@
 ---
 import type { HTMLAttributes } from 'astro/types';
+import { Icon } from 'astro-icon/components';
 
-type Props = HTMLAttributes<'a'>;
+interface Props extends HTMLAttributes<'a'> {
+  icon?: string;
+}
 
-const { href, class: className, ...props } = Astro.props;
+const { href, icon, class: className, ...props } = Astro.props;
 const pathname = Astro.url.pathname.replace(import.meta.env.BASE_URL, '');
 const subpath = pathname.match(/[^/]+/g);
 const isActive = href === pathname || href === `/${subpath?.[0] || ''}`;
@@ -11,8 +14,9 @@ const isActive = href === pathname || href === `/${subpath?.[0] || ''}`;
 
 <a
   href={href}
-  class:list={[className, { 'menu-active': isActive }]}
+  class:list={[className, 'flex items-center gap-1.5', { 'menu-active': isActive }]}
   {...props}
 >
+  {icon && <Icon name={icon} class="h-4 w-4" />}
   <slot />
 </a>

--- a/site/src/layouts/BlogPost.astro
+++ b/site/src/layouts/BlogPost.astro
@@ -33,9 +33,9 @@ const { title, description, pubDate, updatedDate, heroImage, tags } = post.data;
     <main class="container mx-auto px-4 py-8 max-w-6xl flex-1">
       <Breadcrumb
         items={[
-          { label: 'Home', href: '/' },
-          { label: 'Blog', href: '/blog' },
-          { label: title },
+          { label: 'Home', href: '/', icon: 'tabler:home' },
+          { label: 'Blog', href: '/blog', icon: 'tabler:news' },
+          { label: title, icon: 'tabler:article' },
         ]}
       />
 

--- a/site/src/pages/cv.astro
+++ b/site/src/pages/cv.astro
@@ -79,6 +79,7 @@ const speaking = [
     date: 'October 2025',
     description:
       'Presented strategies for streamlining API integrations using Cloudflare Workers for Platforms and Workflows. Demonstrated how AI-driven automation transforms fragmented API workflows into reliable, intelligent pipelines.',
+    presentationUrl: 'https://presentations.diz.rocks/cc25-workers-as-glue',
   },
   {
     title: 'AI on Demand: Serverless AI',
@@ -178,27 +179,25 @@ const skills = {
           Education
         </h2>
 
-        <ul class="timeline timeline-snap-icon max-md:timeline-compact timeline-vertical">
+        <div class="space-y-6">
           {
-            education.map((edu, index) => (
-              <li>
-                {index > 0 && <hr class="bg-secondary" />}
-                <div class="timeline-middle">
-                  <Icon name="tabler:circle-check" class="h-5 w-5 text-secondary" />
-                </div>
-                <div
-                  class={`timeline-${index % 2 === 0 ? 'start' : 'end'} mb-10 ${index % 2 === 0 ? 'md:text-end' : ''}`}
-                >
-                  <time class="font-mono italic text-sm">{edu.period}</time>
-                  <div class="text-lg font-black">{edu.degree}</div>
-                  <div class="text-secondary font-semibold">{edu.institution} <span class="text-base-content/60 font-normal">| {edu.location}</span></div>
+            education.map((edu) => (
+              <div class="card bg-base-200">
+                <div class="card-body">
+                  <h3 class="card-title text-lg">{edu.degree}</h3>
+                  <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+                    <span class="text-secondary font-semibold">{edu.institution}</span>
+                    <span class="text-base-content/60">|</span>
+                    <span class="text-base-content/70">{edu.location}</span>
+                    <span class="text-base-content/60">|</span>
+                    <time class="font-mono italic text-base-content/70">{edu.period}</time>
+                  </div>
                   <p class="mt-2 text-base-content/80">{edu.description}</p>
                 </div>
-                {index < education.length - 1 && <hr class="bg-secondary" />}
-              </li>
+              </div>
             ))
           }
-        </ul>
+        </div>
       </section>
 
       <!-- Speaking Section -->
@@ -213,7 +212,21 @@ const skills = {
             speaking.map((talk) => (
               <div class="card bg-base-200">
                 <div class="card-body">
-                  <h3 class="card-title text-lg">{talk.title}</h3>
+                  <div class="flex items-start justify-between gap-4">
+                    <h3 class="card-title text-lg">{talk.title}</h3>
+                    {talk.presentationUrl && (
+                      <a
+                        href={talk.presentationUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="btn btn-sm btn-ghost gap-1.5 text-primary hover:text-primary-focus shrink-0"
+                        title="View Slides"
+                      >
+                        <Icon name="tabler:presentation" class="h-5 w-5" />
+                        <span class="hidden sm:inline">Slides</span>
+                      </a>
+                    )}
+                  </div>
                   <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
                     <span class="text-primary font-semibold">{talk.event}</span>
                     <span class="text-base-content/60">|</span>

--- a/site/src/pages/cv.astro
+++ b/site/src/pages/cv.astro
@@ -219,7 +219,7 @@ const skills = {
                         href={talk.presentationUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="btn btn-sm btn-ghost gap-1.5 text-primary hover:text-primary-focus shrink-0"
+                        class="btn btn-sm btn-ghost gap-1.5 text-primary shrink-0"
                         title="View Slides"
                       >
                         <Icon name="tabler:presentation" class="h-5 w-5" />


### PR DESCRIPTION
Adds presentation slide links to speaking engagements and replaces timeline with card-based layout
for better readability and mobile experience.

• Add presentation URL field to speaking data with external link button
• Replace timeline layout with card-based design for education section
• Improve responsive spacing and typography consistency
• Add slide access button with presentation icon for enhanced UX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Icons added across navigation and breadcrumb trails for clearer visual cues.
  * Navigation menu now renders consistently from a single source of items.
  * Speaking entries can show a Slides link when available.

* **Style**
  * Education section redesigned to a card-based grid for improved readability and layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->