### PR TITLE
feat: add design philosophy content collection and page

### DIFF
--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,6 +1,20 @@
 import { defineCollection, z } from 'astro:content';
 import { glob } from 'astro/loaders';
 
+const philosophy = defineCollection({
+  loader: glob({ base: './src/content/philosophy', pattern: '*.mdx' }),
+  schema: z.object({
+    title: z.string(),
+    values: z.array(
+      z.object({
+        value: z.string(),
+        aka: z.string().optional(),
+        description: z.string(),
+      }),
+    ),
+  }),
+});
+
 const blog = defineCollection({
   // Load Markdown and MDX files in the `src/content/blog/` directory.
   loader: glob({ base: './src/content/blog', pattern: '**/*.{md,mdx}' }),
@@ -59,4 +73,4 @@ const experience = defineCollection({
     ),
 });
 
-export const collections = { blog, experience };
+export const collections = { blog, experience, philosophy };

--- a/site/src/content/philosophy/philosophy.mdx
+++ b/site/src/content/philosophy/philosophy.mdx
@@ -1,0 +1,95 @@
+---
+title: Design Philosophy
+values:
+  - value: Strong Opinions, Loosely Held
+    aka: Intellectual Humility
+    description: >
+      Clear opinions help teams move quickly and make consistent decisions.
+      At the same time, intellectual humility allows designs to evolve as
+      new evidence or context emerges. Good ideas should withstand scrutiny
+      rather than authority. The strongest systems are shaped through
+      iteration, feedback, and continuous learning.
+
+  - value: Invest in People
+    aka: People-First Engineering
+    description: >
+      Software quality reflects the people and culture behind it. Teams
+      thrive when engineers are trusted, supported, and given room to grow.
+      Clear communication, mentorship, and shared ownership lead to more
+      resilient systems and better outcomes. Sustainable engineering is built
+      on healthy, collaborative teams.
+
+  - value: Observability Everywhere
+    aka: Full-Stack Observability
+    description: >
+      Modern systems are too complex to reason about through intuition alone.
+      Observability—logs, metrics, and traces—should be a first-class concern
+      across the entire stack, from frontend interactions to backend services
+      and infrastructure. A well-instrumented system is easier to debug,
+      safer to change, and faster to improve. If something is happening in
+      production, the system should be able to explain itself.
+
+  - value: Data-Driven Decisions
+    aka: Measure Before You Optimize
+    description: >
+      Intuition can guide exploration, but evidence should guide decisions.
+      Metrics, traces, benchmarks, and real usage data help identify true
+      bottlenecks and prevent wasted optimization effort. Measuring first
+      ensures effort is applied where it delivers real impact. Well-designed
+      systems surface the signals needed to guide improvement.
+
+  - value: Right Tool for the Job
+    aka: Pragmatic Tooling
+    description: >
+      No single language, framework, or platform is best for every problem.
+      A pragmatic, polyglot approach prioritizes fitness for purpose over
+      familiarity or trends. Choosing the right tool means understanding
+      tradeoffs in complexity, performance, operability, and team expertise.
+      Good architecture enables effectiveness rather than enforcing uniformity.
+
+  - value: Avoid Overengineering
+    aka: Avoid Premature Optimization
+    description: >
+      Complexity is a cost that compounds over time. Systems should solve
+      today's problems clearly and directly, resisting the urge to build for
+      hypothetical future needs. Premature optimization and speculative
+      abstractions often reduce clarity and slow teams down. Simpler systems
+      are easier to reason about, adapt, and maintain as requirements evolve.
+
+  - value: Automate Everything
+    aka: Infrastructure as Code
+    description: >
+      Repetition invites error and inconsistency. Infrastructure, testing,
+      deployments, and operational workflows should be automated and
+      version-controlled wherever possible. Automation improves reliability,
+      shortens feedback loops, and frees humans to focus on higher-value
+      problem solving. Any task performed repeatedly is a strong candidate
+      for automation.
+
+  - value: Separation of Concerns
+    aka: Modularity & Loose Coupling
+    description: >
+      Systems are easier to understand and evolve when responsibilities are
+      clearly separated. Components benefit from narrow, well-defined
+      interfaces and minimal shared assumptions. Loose coupling enables
+      independent development, testing, and deployment. Modularity turns
+      change from a risk into a manageable operation.
+
+  - value: Design for Failure
+    aka: Resilience by Design
+    description: >
+      Failure is not an edge case; it is an expected condition in distributed
+      systems. Reliable architectures anticipate failure and recover
+      gracefully when it occurs. Techniques such as retries, timeouts,
+      isolation, and clear failure modes reduce blast radius. Resilient
+      systems degrade predictably rather than catastrophically.
+
+  - value: Lean for Learning
+    aka: Continuous Improvement
+    description: >
+      Strong systems are not finished—they evolve. Short feedback loops,
+      small iterative changes, and learning from real-world usage drive
+      steady improvement. Postmortems, metrics, and experimentation inform
+      better future decisions. Continuous learning turns change into a
+      competitive advantage.
+---

--- a/site/src/pages/philosophy.astro
+++ b/site/src/pages/philosophy.astro
@@ -1,0 +1,47 @@
+---
+import { getCollection } from 'astro:content';
+import BaseHead from '../components/BaseHead.astro';
+import Footer from '../components/Footer.astro';
+import Header from '../components/Header.astro';
+import { SITE_TITLE } from '../consts';
+
+const philosophyEntries = await getCollection('philosophy');
+if (philosophyEntries.length === 0) {
+  throw new Error(
+    "No entries found in 'philosophy' collection. Ensure src/content/philosophy/ contains at least one .mdx file.",
+  );
+}
+const philosophy = philosophyEntries[0];
+const { title, values } = philosophy.data;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead title={`${title} | ${SITE_TITLE}`} description="Core principles that guide how I build software and lead teams" />
+  </head>
+  <body class="min-h-screen flex flex-col">
+    <Header />
+    <main class="container mx-auto px-4 py-8 max-w-4xl flex-1">
+      <h1 class="text-4xl font-bold mb-2">{title}</h1>
+      <p class="text-base-content/70 mb-8">Core principles that guide how I build software and lead teams</p>
+
+      <div class="space-y-6">
+        {
+          values.map((item) => (
+            <div class="card bg-base-200">
+              <div class="card-body">
+                <div class="flex flex-wrap items-center gap-3">
+                  <h2 class="card-title text-xl">{item.value}</h2>
+                  {item.aka && <span class="badge badge-primary badge-outline">{item.aka}</span>}
+                </div>
+                <p class="mt-2 text-base-content/80 leading-relaxed">{item.description}</p>
+              </div>
+            </div>
+          ))
+        }
+      </div>
+    </main>
+    <Footer />
+  </body>
+</html>


### PR DESCRIPTION
Add a new philosophy content collection to showcase core engineering principles and design values. The philosophy page presents ten key principles including observability, people-first engineering, and pragmatic tooling choices.

- Add philosophy content collection with structured schema for values
- Create philosophy.mdx with 10 engineering principles and descriptions
- Build philosophy page with card-based layout for principle display
- Include "aka" badges for alternative terminology alongside core values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Philosophy page showcasing core design principles and organizational values.
  * Added a Philosophy collection and content entry listing multiple principles with aliases and detailed descriptions.
  * Principles displayed in a responsive card-based layout with optional alias badges for clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->