### PR TITLE
refactor: rename philosophy section to principles

### DIFF
--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,10 +1,11 @@
 import { defineCollection, z } from 'astro:content';
 import { glob } from 'astro/loaders';
 
-const philosophy = defineCollection({
-  loader: glob({ base: './src/content/philosophy', pattern: '*.mdx' }),
+const principles = defineCollection({
+  loader: glob({ base: './src/content/principles', pattern: '*.mdx' }),
   schema: z.object({
     title: z.string(),
+    blurb: z.string(),
     values: z.array(
       z.object({
         value: z.string(),
@@ -73,4 +74,4 @@ const experience = defineCollection({
     ),
 });
 
-export const collections = { blog, experience, philosophy };
+export const collections = { blog, experience, principles };

--- a/site/src/content/principles/principles.mdx
+++ b/site/src/content/principles/principles.mdx
@@ -1,5 +1,6 @@
 ---
-title: Design Philosophy
+title: Engineering Principles & Design Philosophy
+blurb: Core principles that guide how I build software and lead teams
 values:
   - value: Strong Opinions, Loosely Held
     aka: Intellectual Humility

--- a/site/src/pages/principles.astro
+++ b/site/src/pages/principles.astro
@@ -5,20 +5,20 @@ import Footer from '../components/Footer.astro';
 import Header from '../components/Header.astro';
 import { SITE_TITLE } from '../consts';
 
-const philosophyEntries = await getCollection('philosophy');
-if (philosophyEntries.length === 0) {
+const principlesEntries = await getCollection('principles');
+if (principlesEntries.length === 0) {
   throw new Error(
-    "No entries found in 'philosophy' collection. Ensure src/content/philosophy/ contains at least one .mdx file.",
+    "No entries found in 'principles' collection. Ensure src/content/principles/ contains at least one .mdx file.",
   );
 }
-const philosophy = philosophyEntries[0];
-const { title, values } = philosophy.data;
+const principles = principlesEntries[0];
+const { title, blurb, values } = principles.data;
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
-    <BaseHead title={`${title} | ${SITE_TITLE}`} description="Core principles that guide how I build software and lead teams" />
+    <BaseHead title={`${title} | ${SITE_TITLE}`} description={blurb} />
   </head>
   <body class="min-h-screen flex flex-col">
     <Header />


### PR DESCRIPTION
Restructure content organization to better reflect the nature of engineering principles and design philosophy. This change improves semantic clarity and provides better context for the content.

- Rename philosophy collection to principles in content config
- Add blurb field to schema for better content description
- Update file paths from philosophy/ to principles/
- Enhance page title to "Engineering Principles & Design Philosophy"
- Update error messages and variable names for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Renamed philosophy content section to principles for improved clarity.
  * Added blurb field to principles metadata.
  * Updated principles page title to "Engineering Principles & Design Philosophy" with dynamic page descriptions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->