### PR TITLE
feat: add skill radar chart component for cv expertise visualization

### DIFF
--- a/site/src/components/SkillRadar.astro
+++ b/site/src/components/SkillRadar.astro
@@ -11,6 +11,7 @@ interface Props {
 }
 
 const { skills, size = 500, title = 'Skill Radar' } = Astro.props;
+if (skills.length === 0) return;
 
 // Chart configuration
 const paddingX = 80; // Extra horizontal padding for labels

--- a/site/src/components/SkillRadar.astro
+++ b/site/src/components/SkillRadar.astro
@@ -1,0 +1,154 @@
+---
+interface Skill {
+  label: string;
+  value: number; // 0-100
+}
+
+interface Props {
+  skills: Skill[];
+  size?: number;
+  title?: string;
+}
+
+const { skills, size = 500, title = 'Skill Radar' } = Astro.props;
+
+// Chart configuration
+const paddingX = 80; // Extra horizontal padding for labels
+const paddingY = 0; // Less vertical padding needed
+const viewBoxWidth = size + paddingX * 2;
+const viewBoxHeight = size + paddingY * 2;
+const centerX = viewBoxWidth / 2;
+const centerY = viewBoxHeight / 2;
+const maxRadius = size * 0.28; // Leave room for labels
+const rings = [0.2, 0.4, 0.6, 0.8, 1.0];
+const numPoints = skills.length;
+const angleStep = (2 * Math.PI) / numPoints;
+const startAngle = -Math.PI / 2; // Start from top
+
+// Pre-compute all coordinates
+function getPoint(index: number, value: number) {
+  const angle = startAngle + index * angleStep;
+  const radius = (value / 100) * maxRadius;
+  return {
+    x: centerX + radius * Math.cos(angle),
+    y: centerY + radius * Math.sin(angle),
+  };
+}
+
+// Generate polygon points string for rings
+const ringPolygons = rings.map((scale) => {
+  return Array.from({ length: numPoints }, (_, i) => {
+    const pt = getPoint(i, scale * 100);
+    return `${pt.x},${pt.y}`;
+  }).join(' ');
+});
+
+// Generate axis lines data
+const axisLines = skills.map((_, i) => {
+  const endpoint = getPoint(i, 100);
+  return { x1: centerX, y1: centerY, x2: endpoint.x, y2: endpoint.y };
+});
+
+// Generate skill polygon points
+const skillPolygon = skills
+  .map((s, i) => {
+    const pt = getPoint(i, s.value);
+    return `${pt.x},${pt.y}`;
+  })
+  .join(' ');
+
+// Generate skill dots data
+const skillDots = skills.map((s, i) => {
+  const pt = getPoint(i, s.value);
+  return { cx: pt.x, cy: pt.y };
+});
+
+// Generate label data
+const labelData = skills.map((skill, i) => {
+  const angle = startAngle + i * angleStep;
+  const labelRadius = maxRadius + 40;
+  const x = centerX + labelRadius * Math.cos(angle);
+  const y = centerY + labelRadius * Math.sin(angle);
+
+  let anchor = 'middle';
+  if (Math.cos(angle) < -0.1) anchor = 'end';
+  else if (Math.cos(angle) > 0.1) anchor = 'start';
+
+  // Split long labels
+  const words = skill.label.split(' ');
+  let lines: string[];
+  if (words.length <= 2) {
+    lines = [skill.label];
+  } else {
+    const mid = Math.ceil(words.length / 2);
+    lines = [words.slice(0, mid).join(' '), words.slice(mid).join(' ')];
+  }
+
+  return { x, y, anchor, lines };
+});
+
+const ariaLabel = `Radar chart showing skill levels: ${skills.map((s) => `${s.label}: ${s.value}%`).join(', ')}`;
+---
+
+<div class="flex flex-col items-center w-full overflow-visible">
+  {title && <h3 class="text-xl font-bold mb-4">{title}</h3>}
+  <svg
+    viewBox={`0 0 ${viewBoxWidth} ${viewBoxHeight}`}
+    class="w-full h-auto max-w-[750px]"
+    role="img"
+    aria-label={ariaLabel}
+  >
+    <!-- Background rings -->
+    {ringPolygons.map((points) => (
+      <polygon
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1"
+        class="text-base-content/15"
+      />
+    ))}
+
+    <!-- Axis lines from center to each vertex -->
+    {axisLines.map((line) => (
+      <line
+        x1={line.x1}
+        y1={line.y1}
+        x2={line.x2}
+        y2={line.y2}
+        stroke="currentColor"
+        stroke-width="1"
+        class="text-base-content/20"
+      />
+    ))}
+
+    <!-- Skill polygon (filled area) -->
+    <polygon
+      points={skillPolygon}
+      class="fill-primary/25 stroke-primary"
+      stroke-width="2"
+    />
+
+    <!-- Skill points -->
+    {skillDots.map((dot) => (
+      <circle cx={dot.cx} cy={dot.cy} r="4" class="fill-primary" />
+    ))}
+
+    <!-- Labels -->
+    {labelData.map((label) => (
+      <text
+        x={label.x}
+        y={label.y}
+        text-anchor={label.anchor}
+        dominant-baseline="middle"
+        class="fill-base-content text-xs font-medium"
+      >
+        {label.lines.map((line, idx) => (
+          <tspan x={label.x} dy={idx === 0 ? 0 : '1.2em'}>
+            {line}
+          </tspan>
+        ))}
+      </text>
+    ))}
+  </svg>
+</div>

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,10 +1,11 @@
 import { defineCollection, z } from 'astro:content';
 import { glob } from 'astro/loaders';
 
-const philosophy = defineCollection({
-  loader: glob({ base: './src/content/philosophy', pattern: '*.mdx' }),
+const principles = defineCollection({
+  loader: glob({ base: './src/content/principles', pattern: '*.mdx' }),
   schema: z.object({
     title: z.string(),
+    blurb: z.string(),
     values: z.array(
       z.object({
         value: z.string(),
@@ -73,4 +74,4 @@ const experience = defineCollection({
     ),
 });
 
-export const collections = { blog, experience, philosophy };
+export const collections = { blog, experience, principles };

--- a/site/src/content/principles/principles.mdx
+++ b/site/src/content/principles/principles.mdx
@@ -1,5 +1,6 @@
 ---
-title: Design Philosophy
+title: Engineering Principles & Design Philosophy
+blurb: Core principles that guide how I build software and lead teams
 values:
   - value: Strong Opinions, Loosely Held
     aka: Intellectual Humility

--- a/site/src/pages/cv.astro
+++ b/site/src/pages/cv.astro
@@ -6,6 +6,7 @@ import ExperienceCard from '../components/ExperienceCard.astro';
 import Footer from '../components/Footer.astro';
 import GroupedExperienceCard from '../components/GroupedExperienceCard.astro';
 import Header from '../components/Header.astro';
+import SkillRadar from '../components/SkillRadar.astro';
 import { getTechIcon, SITE_TITLE } from '../consts';
 import {
   parseGroupedExperienceContent,
@@ -113,6 +114,17 @@ const skills = {
     'Modbus',
   ],
 };
+
+const expertise = [
+  { label: 'Systems Programming', value: 90 },
+  { label: 'Cloud & DevOps', value: 95 },
+  { label: 'Distributed Systems', value: 90 },
+  { label: 'Data Engineering', value: 70 },
+  { label: 'AI & ML', value: 75 },
+  { label: 'Frontend & Web', value: 75 },
+  { label: 'IoT & Embedded', value: 65 },
+  { label: 'Observability & SRE', value: 85 },
+];
 ---
 
 <!doctype html>
@@ -239,6 +251,20 @@ const skills = {
               </div>
             ))
           }
+        </div>
+      </section>
+
+      <!-- Expertise Section -->
+      <section class="mb-12">
+        <h2 class="text-2xl font-bold mb-6 flex items-center gap-2">
+          <Icon name="tabler:chart-radar" class="h-6 w-6" />
+          Expertise
+        </h2>
+
+        <div class="card bg-base-200">
+          <div class="card-body items-center">
+            <SkillRadar skills={expertise} title="" />
+          </div>
         </div>
       </section>
 

--- a/site/src/pages/cv.astro
+++ b/site/src/pages/cv.astro
@@ -93,25 +93,31 @@ const speaking = [
 ];
 
 const skills = {
-  Languages: [
-    'Python',
-    'Rust',
-    'C/C++',
-    'Java',
-    'Ruby',
-    'JavaScript/ES6',
-    'Lua',
-    'Haskell',
-  ],
-  Web: ['Node.js', 'React', 'Redux', 'Express', 'GraphQL'],
-  Databases: ['PostgreSQL', 'MongoDB', 'DynamoDB'],
-  'Hardware & Infrastructure': [
-    'Docker',
+  Languages: ['Golang', 'Python', 'Rust', 'TypeScript', 'C/C++', 'Ruby'],
+  'Web & Frontend': ['React', 'Node.js', 'GraphQL', 'TanStack', 'Redux'],
+  'Cloud & DevOps': [
     'AWS',
-    'PCB Design',
-    'Raspberry Pi',
-    'Arduino',
-    'Modbus',
+    'Kubernetes',
+    'Docker',
+    'Terraform',
+    'Cloudflare Workers',
+    'GitHub Actions',
+  ],
+  'Databases & Streaming': [
+    'PostgreSQL',
+    'DynamoDB',
+    'Redis',
+    'Kafka',
+    'Clickhouse',
+    'DuckDB',
+  ],
+  Observability: ['Prometheus', 'Grafana', 'OpenTelemetry', 'VictoriaMetrics'],
+  'IoT & Edge': [
+    'Computer Vision',
+    'GPU Acceleration',
+    'Temporal',
+    'Ansible',
+    'AXIS ACAP',
   ],
 };
 

--- a/site/src/pages/principles.astro
+++ b/site/src/pages/principles.astro
@@ -24,7 +24,7 @@ const { title, blurb, values } = principles.data;
     <Header />
     <main class="container mx-auto px-4 py-8 max-w-4xl flex-1">
       <h1 class="text-4xl font-bold mb-2">{title}</h1>
-      <p class="text-base-content/70 mb-8">Core principles that guide how I build software and lead teams</p>
+      <p class="text-base-content/70 mb-8">{blurb}</p>
 
       <div class="space-y-6">
         {

--- a/site/src/pages/principles.astro
+++ b/site/src/pages/principles.astro
@@ -5,20 +5,20 @@ import Footer from '../components/Footer.astro';
 import Header from '../components/Header.astro';
 import { SITE_TITLE } from '../consts';
 
-const philosophyEntries = await getCollection('philosophy');
-if (philosophyEntries.length === 0) {
+const principlesEntries = await getCollection('principles');
+if (principlesEntries.length === 0) {
   throw new Error(
-    "No entries found in 'philosophy' collection. Ensure src/content/philosophy/ contains at least one .mdx file.",
+    "No entries found in 'principles' collection. Ensure src/content/principles/ contains at least one .mdx file.",
   );
 }
-const philosophy = philosophyEntries[0];
-const { title, values } = philosophy.data;
+const principles = principlesEntries[0];
+const { title, blurb, values } = principles.data;
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
-    <BaseHead title={`${title} | ${SITE_TITLE}`} description="Core principles that guide how I build software and lead teams" />
+    <BaseHead title={`${title} | ${SITE_TITLE}`} description={blurb} />
   </head>
   <body class="min-h-screen flex flex-col">
     <Header />

--- a/site/src/pages/uses.astro
+++ b/site/src/pages/uses.astro
@@ -71,7 +71,7 @@ const categories: UsesCategory[] = [
         description: 'Dotfile manager',
         icon: 'tabler:settings-share',
         link: 'https://chezmoi.io/',
-      }
+      },
     ],
   },
   {

--- a/site/src/pages/uses.astro
+++ b/site/src/pages/uses.astro
@@ -23,7 +23,6 @@ const categories: UsesCategory[] = [
   {
     title: 'Editor & IDE',
     icon: 'tabler:code',
-    span: 'large',
     items: [
       {
         name: 'VS Code',
@@ -32,10 +31,10 @@ const categories: UsesCategory[] = [
         link: 'https://code.visualstudio.com/',
       },
       {
-        name: 'Neovim',
+        name: 'Helix',
         description: 'For quick edits and terminal work',
-        icon: 'logos:neovim',
-        link: 'https://neovim.io/',
+        icon: 'simple-icons:helix',
+        link: 'https://helix-editor.com/',
       },
       {
         name: 'JetBrains IDEs',
@@ -50,23 +49,29 @@ const categories: UsesCategory[] = [
     icon: 'tabler:terminal-2',
     items: [
       {
-        name: 'Kitty',
+        name: 'Alacritty',
         description: 'GPU-accelerated terminal',
-        icon: 'tabler:brand-open-source',
-        link: 'https://sw.kovidgoyal.net/kitty/',
+        icon: 'simple-icons:alacritty',
+        link: 'https://alacritty.org/',
       },
       {
         name: 'Fish Shell',
         description: 'Friendly interactive shell',
-        icon: 'tabler:fish',
+        icon: 'simple-icons:fishshell',
         link: 'https://fishshell.com/',
       },
       {
         name: 'Starship',
         description: 'Cross-shell prompt',
-        icon: 'tabler:rocket',
+        icon: 'simple-icons:starship',
         link: 'https://starship.rs/',
       },
+      {
+        name: 'Chezmoi',
+        description: 'Dotfile manager',
+        icon: 'tabler:settings-share',
+        link: 'https://chezmoi.io/',
+      }
     ],
   },
   {


### PR DESCRIPTION
This commit introduces an interactive radar chart component to display technical expertise levels on
the CV page. The radar chart provides a visual representation of skills across different domains.

- Add SkillRadar.astro component with configurable skills, size, and title props
- Implement responsive SVG radar chart with polygon rendering and dynamic labels
- Add expertise section to CV page showcasing 8 technical domains with proficiency levels
- Update uses page with current tool preferences (Helix editor, Alacritty terminal, Chezmoi
dotfiles)
- Include accessibility features with proper ARIA labels and semantic markup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive Skill Radar on the CV to visualize expertise across domains and updated the skills taxonomy.

* **Documentation**
  * Replaced the "Philosophy" section with a "Principles" collection, added a blurb, and made page descriptions dynamic.

* **Content Updates**
  * Updated recommended tools: Helix (editor), Alacritty (terminal), Fish shell, Starship prompt, and added Chezmoi for dotfile management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->