### PR TITLE
feat: restructure cv experience content with separate highlights and description sections

### DIFF
--- a/site/src/components/ExperienceCard.astro
+++ b/site/src/components/ExperienceCard.astro
@@ -9,7 +9,8 @@ interface Props {
   companyUrl?: string;
   location: string;
   period: string;
-  description: string;
+  highlights: string;
+  description?: string;
   responsibilities?: string[];
   technologies: string[];
 }
@@ -21,6 +22,7 @@ const {
   companyUrl,
   location,
   period,
+  highlights,
   description,
   responsibilities = [],
   technologies,
@@ -85,10 +87,10 @@ const hasMoreTech = technologies.length > maxCollapsedTech;
         </div>
       </div>
 
-      <!-- Collapsed content (description + limited tech) -->
+      <!-- Collapsed content (highlights + limited tech) -->
       <div class="experience-collapsed grid grid-rows-[1fr] transition-all duration-200 ease-out mt-4">
         <div class="overflow-hidden">
-          <p class="text-sm text-base-content/70 leading-relaxed">{description}</p>
+          <p class="text-sm text-base-content/70 leading-relaxed">{highlights}</p>
           {technologies.length > 0 && (
             <div class="flex flex-wrap gap-2 mt-3">
               {technologies.slice(0, maxCollapsedTech).map((tech) => (
@@ -108,9 +110,12 @@ const hasMoreTech = technologies.length > maxCollapsedTech;
         </div>
       </div>
 
-      <!-- Expanded content (responsibilities + all tech) -->
+      <!-- Expanded content (description + responsibilities + all tech) -->
       <div class="experience-expanded grid grid-rows-[0fr] transition-all duration-200 ease-out mt-0">
         <div class="overflow-hidden">
+          {description && (
+            <p class="text-sm text-base-content/80 leading-relaxed mb-4">{description}</p>
+          )}
           {responsibilities.length > 0 && (
             <ul class="space-y-1.5 text-sm mb-4">
               {responsibilities.map((item) => (

--- a/site/src/components/GroupedExperienceCard.astro
+++ b/site/src/components/GroupedExperienceCard.astro
@@ -6,7 +6,8 @@ interface Role {
   id: string;
   title: string;
   period: string;
-  description: string;
+  highlights: string;
+  description?: string;
   responsibilities?: string[];
   technologies: string[];
 }
@@ -115,10 +116,10 @@ const maxCollapsedTech = 8;
                 </div>
               </div>
 
-              <!-- Collapsed content (description + limited tech) -->
+              <!-- Collapsed content (highlights + limited tech) -->
               <div class="role-collapsed grid grid-rows-[1fr] transition-all duration-200 ease-out mt-2">
                 <div class="overflow-hidden">
-                  <p class="text-sm text-base-content/70 leading-relaxed">{role.description}</p>
+                  <p class="text-sm text-base-content/70 leading-relaxed">{role.highlights}</p>
                   {role.technologies.length > 0 && (
                     <div class="flex flex-wrap gap-2 mt-3">
                       {role.technologies.slice(0, maxCollapsedTech).map((tech) => (
@@ -138,9 +139,12 @@ const maxCollapsedTech = 8;
                 </div>
               </div>
 
-              <!-- Expanded content (responsibilities + all tech) -->
+              <!-- Expanded content (description + responsibilities + all tech) -->
               <div class="role-expanded grid grid-rows-[0fr] transition-all duration-200 ease-out mt-0">
                 <div class="overflow-hidden">
+                  {role.description && (
+                    <p class="text-sm text-base-content/80 leading-relaxed mb-3">{role.description}</p>
+                  )}
                   {role.responsibilities && role.responsibilities.length > 0 && (
                     <ul class="space-y-1.5 text-sm mb-3">
                       {role.responsibilities.map((item) => (

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -104,6 +104,8 @@ export const TECH_ICON_MAP: Record<string, string> = {
   Prometheus: 'logos:prometheus',
   VictoriaMetrics: 'simple-icons:victoriametrics',
   Clickhouse: 'simple-icons:clickhouse',
+  Timescale: 'simple-icons:timescale',
+  Elasticsearch: 'logos:elasticsearch',
   'Cloudflare Workers': 'logos:cloudflare-workers-icon',
   'C++': 'logos:c-plusplus',
   Rust: 'logos:rust',

--- a/site/src/content/cv/experience/01-targeted-victory.mdx
+++ b/site/src/content/cv/experience/01-targeted-victory.mdx
@@ -18,9 +18,13 @@ technologies:
   - Grunt
 ---
 
-## Summary
+## Highlights
 
 Co-developed fundraising portal with REST API and OAuth. Managed server infrastructure reducing hosting costs by $20,000/month.
+
+## Description
+
+Full-stack development and DevOps role at a leading digital political consulting firm, working on high-traffic fundraising platforms for major political campaigns and advocacy organizations.
 
 ## Details
 

--- a/site/src/content/cv/experience/02-knocki.mdx
+++ b/site/src/content/cv/experience/02-knocki.mdx
@@ -19,9 +19,13 @@ technologies:
   - Express.js
 ---
 
-## Summary
+## Highlights
 
 Co-architected serverless backend using Lambda and DynamoDB. Developed hardware OTA process and built admin dashboard with React.
+
+## Description
+
+Early-stage smart home IoT startup building a surface-mounted gesture sensor that transforms any surface into a smart controller. Responsible for cloud infrastructure and firmware management systems.
 
 ## Details
 

--- a/site/src/content/cv/experience/03-pason-power.mdx
+++ b/site/src/content/cv/experience/03-pason-power.mdx
@@ -12,6 +12,7 @@ technologies:
   - Node.js
   - Python
   - PostgreSQL
+  - Timescale
   - AWS Lambda
   - DynamoDB
   - Kinesis
@@ -22,9 +23,13 @@ technologies:
   - Webpack
 ---
 
-## Summary
+## Highlights
 
 Established critical infrastructure including CI/CD and infrastructure-as-code. Designed onboarding systems managing 150+ configuration parameters. Led team expansion from 5 to 20 members.
+
+## Description
+
+Pason Power is an energy technology company providing real-time IoT monitoring and optimization for commercial solar and battery storage systems. Led cloud architecture and engineering growth as the company scaled from seed to Series A.
 
 ## Details
 

--- a/site/src/content/cv/experience/04-cloudflare.mdx
+++ b/site/src/content/cv/experience/04-cloudflare.mdx
@@ -51,6 +51,7 @@ roles:
       - Prometheus
       - VictoriaMetrics
       - Clickhouse
+      - Elasticsearch
       - PostgreSQL
       - TypeScript
       - Cloudflare Workers
@@ -58,9 +59,13 @@ roles:
 
 ## cloudflare-workers-ai
 
-### Summary
+### Highlights
 
-Cloudflare's edge-native, serverless vector database powering AI products and embeddings workflows.
+Designed custom vector storage format with IVF+PQ for edge query efficiency. Built metadata storage engine and dynamic re-indexer for real-time retrieval.
+
+### Description
+
+Vectorize is Cloudflare's edge-native, serverless vector database, powering AI products and embeddings workflows.
 
 ### Details
 
@@ -70,9 +75,13 @@ Cloudflare's edge-native, serverless vector database powering AI products and em
 
 ## cloudflare-workers-core
 
-### Summary
+### Highlights
 
-Managed the build pipeline and configuration systems for Cloudflare Workers.
+Launched Workers for Platforms with multi-tenant V8 runtime. Implemented privileged bindings and expanded edge storage architecture.
+
+### Description
+
+Core platform responsible for managing the build pipeline and configuration systems for Cloudflare Workers.
 
 ### Details
 
@@ -82,12 +91,17 @@ Managed the build pipeline and configuration systems for Cloudflare Workers.
 
 ## cloudflare-internal-tools
 
-### Summary
+### Highlights
 
-Cross-team abstractions used across Cloudflare, serving both internal developers and external product surfaces.
+Launched customer alerting platform with SLO-based anomaly detection. Operated Kafka messaging system processing 1T+ messages daily.
+
+### Description
+
+Internal Tools creates cross-team abstractions used across Cloudflare, serving both internal developers and external product surfaces.
 
 ### Details
 
 - Architected and launched Cloudflare's customer alerting platform, enabling service-based alert dispatch with enriched context via VictoriaMetrics and Clickhouse. Implemented multi-window SLO burn-rate anomaly detection to improve incident responsiveness
 - Operated and optimized Cloudflare's Kafka-backed internal messaging system powering 300+ producers/consumers across 15 brokers, processing over 1T messages per day
 - Spearheaded the Search Engine Crawl Hints initiative with Microsoft and Yandex, integrating with Cloudflare's cache invalidation stack to reduce redundant crawls and network load
+- Managed and optimized a multi-node Elasticsearch cluster supporting Cloudflare's global customer base, implementing automated index lifecycle management and performance tuning across 50+ production indices

--- a/site/src/content/cv/experience/05-terminal-industries.mdx
+++ b/site/src/content/cv/experience/05-terminal-industries.mdx
@@ -41,7 +41,11 @@ technologies:
   - Claude Code
 ---
 
-## Summary
+## Highlights
+
+Founding engineer bootstrapping core infrastructure with multi-tenant IaC. Built Temporal workflow engine with CV triggers and managed fleet of 100+ edge devices.
+
+## Description
 
 Terminal Industries is reimagining global shipping and logistics using computer vision and edge computing.
 

--- a/site/src/content/cv/experience/README.md
+++ b/site/src/content/cv/experience/README.md
@@ -37,15 +37,19 @@ technologies:
   - Tech2
 ---
 
-## Summary
+## Highlights
 
-Brief description of the role and company.
+1-2 sentences summarizing key accomplishments and impact (shown in condensed view).
+
+## Description
+
+Context about the role, team, or company (shown in expanded view).
 
 ## Details
 
-- Accomplishment or responsibility one
-- Accomplishment or responsibility two
-- Accomplishment or responsibility three
+- Detailed accomplishment or responsibility one
+- Detailed accomplishment or responsibility two
+- Detailed accomplishment or responsibility three
 ```
 
 ## Grouped Position Template (Multiple Roles at One Company)
@@ -77,25 +81,33 @@ roles:
 
 ## company-role-one
 
-### Summary
+### Highlights
 
-Description of this role.
+1-2 sentences summarizing key accomplishments for this role.
+
+### Description
+
+Context about the team or product for this role.
 
 ### Details
 
-- Accomplishment one
-- Accomplishment two
+- Detailed accomplishment one
+- Detailed accomplishment two
 
 ## company-role-two
 
-### Summary
+### Highlights
 
-Description of this role.
+1-2 sentences summarizing key accomplishments for this role.
+
+### Description
+
+Context about the team or product for this role.
 
 ### Details
 
-- Accomplishment one
-- Accomplishment two
+- Detailed accomplishment one
+- Detailed accomplishment two
 ```
 
 ## Schema Reference
@@ -126,7 +138,15 @@ Description of this role.
 
 The MDX body is parsed to extract:
 
-- **Single positions**: `## Summary` and `## Details` sections
-- **Grouped positions**: `## {role-id}` sections, each with `### Summary` and `### Details`
+- **Single positions**: `## Highlights`, `## Description`, and `## Details` sections
+- **Grouped positions**: `## {role-id}` sections, each with `### Highlights`, `### Description`, and `### Details`
 
-The `## Details` section should contain a markdown list (`- item`). These become the expandable bullet points on the CV page.
+### Section Usage
+
+| Section | Display | Purpose |
+|---------|---------|---------|
+| `Highlights` | Condensed (collapsed) view | 1-2 sentences of key accomplishments/impact |
+| `Description` | Expanded view | Context about the role, team, or company |
+| `Details` | Expanded view | Markdown list (`- item`) of detailed responsibilities |
+
+The `Details` section becomes the expandable bullet points on the CV page.

--- a/site/src/pages/cv.astro
+++ b/site/src/pages/cv.astro
@@ -28,7 +28,8 @@ const processedExperience = experienceEntries.map((entry) => {
 
     const processedRoles = data.roles.map((role) => ({
       ...role,
-      description: roleContent[role.id]?.summary || '',
+      highlights: roleContent[role.id]?.highlights || '',
+      description: roleContent[role.id]?.description || '',
       responsibilities: roleContent[role.id]?.details || [],
     }));
 
@@ -55,7 +56,8 @@ const processedExperience = experienceEntries.map((entry) => {
     companyUrl: data.companyUrl,
     location: data.location,
     period: data.period,
-    description: content.summary,
+    highlights: content.highlights,
+    description: content.description,
     responsibilities: content.details,
     technologies: data.technologies,
   };
@@ -179,6 +181,7 @@ const expertise = [
                     companyUrl={exp.companyUrl}
                     location={exp.location}
                     period={exp.period}
+                    highlights={exp.highlights}
                     description={exp.description}
                     responsibilities={exp.responsibilities}
                     technologies={exp.technologies}

--- a/site/src/pages/uses.astro
+++ b/site/src/pages/uses.astro
@@ -57,8 +57,14 @@ const categories: UsesCategory[] = [
       {
         name: 'Fish Shell',
         description: 'Friendly interactive shell',
-        icon: 'simple-icons:fishshell',
+        icon: 'tabler:fish',
         link: 'https://fishshell.com/',
+      },
+      {
+        name: 'Zellij',
+        description: 'Terminal multiplexer',
+        icon: 'tabler:table-column',
+        link: 'https://zellij.dev/',
       },
       {
         name: 'Starship',


### PR DESCRIPTION
Refactors CV experience cards to display content more effectively by separating summary information from detailed context. Highlights appear in the collapsed view while descriptions provide additional context in the expanded view.

- Add highlights field to experience interfaces and components
- Split MDX content parsing to handle highlights, description, and details sections separately
- Update all experience MDX files to use new three-section structure (highlights/description/details)
- Add Timescale and Elasticsearch icons to technology mapping
- Include Zellij terminal multiplexer in uses page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experience cards now show "Highlights" in collapsed view; expanded view shows description (if present), responsibilities, and full tech lists.

* **Documentation**
  * CV content restructured: "Summary" → "Highlights" + new "Description" sections; guidance and examples updated.
  * Parsing output updated to expose highlights and description alongside details.
  * Added Timescale and Elasticsearch to technology mappings.

* **New Items**
  * Added Zellij to the tools list.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->