### PR TITLE
feat: add git hooks with biome and markdownlint integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
         run: npm ci
 
       - name: Run Biome lint
-        run: npm run lint
+        run: mise run lint
 
       - name: Run markdownlint
-        run: markdownlint 'src/content/blog/**/*.md' --config .markdownlint.json
+        run: mise run lint:md -- 'src/content/blog/**/*.md'
 
       - name: Run Harper grammar check (blog)
         # TODO: Remove continue-on-error once placeholder Lorem Ipsum content is replaced

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,8 @@ Pre-commit hooks (via hk) run Biome and markdownlint on staged files. Install wi
 ## CI Pipeline
 
 GitHub Actions runs on push/PR to main (site/ only):
-1. `npm run lint` (Biome)
-2. markdownlint on blog content
+1. `mise run lint` (Biome)
+2. `mise run lint:md` on blog content
 3. Grammar check via Harper
 
 Note: `infra/` has no CI validation yet (placeholder for future Terraform).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,10 @@ HQ is a monorepo containing:
 └── .github/    # CI workflows
 ```
 
+## Git Hooks
+
+Pre-commit hooks (via hk) run Biome and markdownlint on staged files. Install with `mise x -- hk install --mise`.
+
 ## CI Pipeline
 
 GitHub Actions runs on push/PR to main (site/ only):

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ This is my personal monorepo—the nerve center where my website lives and my in
 git clone https://github.com/ndisidore/hq.git
 cd hq
 
+# Install tools and git hooks
+mise install
+mise x -- hk install --mise
+
 # Enter the site dimension
 cd site
 npm install
@@ -61,7 +65,7 @@ npm run dev
 | **Content** | Markdown/MDX with Zod-validated frontmatter |
 | **Hosting** | [Cloudflare Workers](https://workers.cloudflare.com) |
 | **Linting** | [Biome](https://biomejs.dev), markdownlint, [Harper](https://github.com/Automattic/harper) |
-| **Tooling** | [mise](https://mise.jdx.dev) for version management |
+| **Tooling** | [mise](https://mise.jdx.dev) for version management, [hk](https://hk.jdx.dev) for git hooks |
 | **Infra** | Terraform (coming to a `terraform apply` near you) |
 
 ## CI Pipeline

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,0 +1,23 @@
+amends "package://github.com/jdx/hk/releases/download/v1.29.0/hk@1.29.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.29.0/hk@1.29.0#/Builtins.pkl"
+
+local linters = new Mapping<String, Step> {
+    ["biome"] {
+        glob = List("site/**/*.js", "site/**/*.ts", "site/**/*.tsx", "site/**/*.astro", "site/**/*.json")
+        check = "mise //site:lint:biome -- $(echo '{{files}}' | sed 's|site/||g')"
+        fix = "mise //site:lint:biome:fix -- $(echo '{{files}}' | sed 's|site/||g')"
+    }
+    ["markdownlint"] {
+        glob = List("site/**/*.md", "!site/node_modules/**")
+        check = "mise //site:lint:md -- $(echo '{{files}}' | sed 's|site/||g')"
+        fix = "mise //site:lint:md:fix -- $(echo '{{files}}' | sed 's|site/||g')"
+    }
+}
+
+hooks {
+    ["pre-commit"] {
+        fix = true
+        stash = "git"
+        steps = linters
+    }
+}

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,13 @@
+experimental_monorepo_root = true
+
+[tools]
+hk = "1.29.0"
+pkl = "0.30.2"
+
+[env]
+MISE_EXPERIMENTAL = "1"
+HK_MISE = "1"
+
+[tasks.pre-commit]
+run = "hk run pre-commit"
+description = "Run pre-commit hooks"

--- a/site/.harper/dictionary.txt
+++ b/site/.harper/dictionary.txt
@@ -28,3 +28,5 @@ pre
 img
 href
 src
+PQ
+IaC

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -70,6 +70,7 @@ To add other icon sets, install `@iconify-json/<set-name>`.
 ## Code Style
 
 Biome handles linting and formatting:
+
 - Single quotes, always semicolons
 - 2-space indentation
 - Tailwind CSS directives enabled
@@ -80,13 +81,14 @@ Markdown files in `src/content/blog/` are linted with markdownlint and grammar-c
 
 If the Playwright MCP server is available, use it to verify UI changes:
 
-1. Start the dev server with `npm run dev` (runs on http://localhost:4321)
+1. Start the dev server with `npm run dev` (runs on <http://localhost:4321>)
 2. Use `browser_navigate` to load pages
 3. Use `browser_snapshot` to inspect the accessibility tree and verify elements
 4. Use `browser_take_screenshot` to capture visual state
 5. Use `browser_click`, `browser_hover`, etc. to test interactions
 
 This is especially useful for:
+
 - Verifying responsive layouts (use `browser_resize` for different viewport sizes)
 - Testing hover states and dropdowns
 - Checking theme switching behavior

--- a/site/README.md
+++ b/site/README.md
@@ -21,7 +21,7 @@
 All commands run from this directory (`site/`):
 
 | Command | Action |
-|---------|--------|
+| ------- | ------ |
 | `npm run dev` | Start dev server at `localhost:4321` |
 | `npm run build` | Build production site to `./dist/` |
 | `npm run preview` | Build and preview locally via Wrangler |
@@ -46,7 +46,7 @@ mise trust && mise install
 **Managed tools:**
 
 | Tool | Version | Purpose |
-|------|---------|---------|
+| ---- | ------- | ------- |
 | Node.js | LTS | Runtime |
 | markdownlint-cli | latest | Markdown linting |
 | harper-cli | latest | Grammar checking |
@@ -58,7 +58,7 @@ mise trust && mise install
 
 ### Project Structure
 
-```
+```text
 src/
 ├── assets/         # Images, logos, static assets
 ├── components/     # Astro/UI components
@@ -78,6 +78,7 @@ scripts/            # Build/CI scripts
 Blog posts live in `src/content/blog/` as Markdown or MDX files. The content schema is defined in `src/content.config.ts` with Zod validation.
 
 **Required frontmatter:**
+
 ```yaml
 ---
 title: "Your Post Title"
@@ -88,6 +89,7 @@ tags: ["astro", "webdev"]
 ```
 
 **Optional fields:**
+
 - `updatedDate` - When the post was last updated
 - `heroImage` - Featured image path
 
@@ -96,7 +98,7 @@ tags: ["astro", "webdev"]
 File-based routing in `src/pages/`:
 
 | Route | File | Description |
-|-------|------|-------------|
+| ----- | ---- | ----------- |
 | `/` | `index.astro` | Home page |
 | `/blog` | `blog/index.astro` | Blog listing |
 | `/blog/[slug]` | `blog/[...slug].astro` | Individual blog posts |
@@ -114,7 +116,7 @@ The site supports extensive theming via [DaisyUI](https://daisyui.com/docs/theme
 Icons use [Iconify](https://iconify.design/) via `astro-icon`. Three icon sets are installed:
 
 | Set | Prefix | Browse | Use Case |
-|-----|--------|--------|----------|
+| --- | ------ | ------ | -------- |
 | [Tabler](https://icon-sets.iconify.design/tabler/) | `tabler:` | [Browse](https://icon-sets.iconify.design/tabler/) | UI icons |
 | [Simple Icons](https://icon-sets.iconify.design/simple-icons/) | `simple-icons:` | [Browse](https://icon-sets.iconify.design/simple-icons/) | Brand icons |
 | [Logos](https://icon-sets.iconify.design/logos/) | `logos:` | [Browse](https://icon-sets.iconify.design/logos/) | Tech/brand logos |
@@ -133,7 +135,7 @@ import { Icon } from 'astro-icon/components';
 ## Key Files
 
 | File | Purpose |
-|------|---------|
+| ---- | ------- |
 | `src/consts.ts` | Site metadata (title, author, social links) |
 | `src/styles/app.css` | Global styles and Tailwind directives |
 | `src/layouts/BlogPost.astro` | Blog post layout with TOC, metadata, navigation |
@@ -153,6 +155,7 @@ import { Icon } from 'astro-icon/components';
 - Tailwind CSS directives enabled
 
 Markdown files in `src/content/blog/` are additionally linted with:
+
 - **markdownlint** - Structural consistency
 - **Harper** - Grammar checking (via pandoc preprocessing)
 

--- a/site/mise.toml
+++ b/site/mise.toml
@@ -3,3 +3,28 @@ node = "lts"
 "npm:markdownlint-cli" = "latest"
 harper-cli = "latest"
 pandoc = "latest"
+
+# These tasks run from site/ context, so paths are relative
+[tasks."lint:biome"]
+run = "npx @biomejs/biome check"
+description = "Run Biome linter"
+
+[tasks."lint:biome:fix"]
+run = "npx @biomejs/biome check --write"
+description = "Run Biome with auto-fix"
+
+[tasks."lint:md"]
+run = "markdownlint --config .markdownlint.json"
+description = "Run markdownlint"
+
+[tasks."lint:md:fix"]
+run = "markdownlint --config .markdownlint.json --fix"
+description = "Run markdownlint with auto-fix"
+
+[tasks.lint]
+run = "npm run lint"
+description = "Run all linters (Biome + tsc)"
+
+[tasks."lint:fix"]
+run = "npm run format:fix && npm run lint:fix"
+description = "Auto-fix all lint issues"

--- a/site/scripts/grammar-check.sh
+++ b/site/scripts/grammar-check.sh
@@ -19,7 +19,8 @@ for file in "${files[@]}"; do
   if [[ -f "$file" ]]; then
     echo "Checking: $file"
     # Strip markdown syntax with pandoc, then run harper
-    if ! pandoc -t plain "$file" | harper-cli lint --user-dict-path "$DICT_PATH"; then
+    # Use -f markdown to handle .mdx files without warnings
+    if ! pandoc -f markdown -t plain "$file" | harper-cli lint --user-dict-path "$DICT_PATH"; then
       exit_code=1
     fi
     echo ""

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -103,7 +103,7 @@ export const TECH_ICON_MAP: Record<string, string> = {
   Kafka: 'logos:kafka-icon',
   Prometheus: 'logos:prometheus',
   VictoriaMetrics: 'simple-icons:victoriametrics',
-  Clickhouse: 'simple-icons:clickhouse',
+  ClickHouse: 'simple-icons:clickhouse',
   Timescale: 'simple-icons:timescale',
   Elasticsearch: 'logos:elasticsearch',
   'Cloudflare Workers': 'logos:cloudflare-workers-icon',

--- a/site/src/content/cv/experience/04-cloudflare.mdx
+++ b/site/src/content/cv/experience/04-cloudflare.mdx
@@ -34,7 +34,7 @@ roles:
       - "Cap'n Proto"
       - Kafka
       - Prometheus
-      - Clickhouse
+      - ClickHouse
       - Ceph
       - Quicksilver
       - PostgreSQL
@@ -50,7 +50,7 @@ roles:
       - Kafka
       - Prometheus
       - VictoriaMetrics
-      - Clickhouse
+      - ClickHouse
       - Elasticsearch
       - PostgreSQL
       - TypeScript
@@ -101,7 +101,7 @@ Internal Tools creates cross-team abstractions used across Cloudflare, serving b
 
 ### Details
 
-- Architected and launched Cloudflare's customer alerting platform, enabling service-based alert dispatch with enriched context via VictoriaMetrics and Clickhouse. Implemented multi-window SLO burn-rate anomaly detection to improve incident responsiveness
+- Architected and launched Cloudflare's customer alerting platform, enabling service-based alert dispatch with enriched context via VictoriaMetrics and ClickHouse. Implemented multi-window SLO burn-rate anomaly detection to improve incident responsiveness
 - Operated and optimized Cloudflare's Kafka-backed internal messaging system powering 300+ producers/consumers across 15 brokers, processing over 1T messages per day
 - Spearheaded the Search Engine Crawl Hints initiative with Microsoft and Yandex, integrating with Cloudflare's cache invalidation stack to reduce redundant crawls and network load
 - Managed and optimized a multi-node Elasticsearch cluster supporting Cloudflare's global customer base, implementing automated index lifecycle management and performance tuning across 50+ production indices

--- a/site/src/content/cv/experience/README.md
+++ b/site/src/content/cv/experience/README.md
@@ -10,7 +10,7 @@ MDX files for CV work experience. Each file represents a position or grouped set
 
 ## File Structure
 
-```
+```text
 experience/
 ├── 01-targeted-victory.mdx    # Oldest position
 ├── 02-knocki.mdx
@@ -113,7 +113,7 @@ Context about the team or product for this role.
 ## Schema Reference
 
 | Field | Type | Required | Description |
-|-------|------|----------|-------------|
+| ----- | ---- | -------- | ----------- |
 | `id` | string | Yes | URL-friendly identifier (used for hash links) |
 | `title` | string | Yes | Job title |
 | `company` | string | Yes | Company name |
@@ -128,7 +128,7 @@ Context about the team or product for this role.
 ### Role Schema (for grouped positions)
 
 | Field | Type | Required | Description |
-|-------|------|----------|-------------|
+| ----- | ---- | -------- | ----------- |
 | `id` | string | Yes | Must match the `## id` header in MDX body |
 | `title` | string | Yes | Role title |
 | `period` | string | Yes | Role period |
@@ -144,7 +144,7 @@ The MDX body is parsed to extract:
 ### Section Usage
 
 | Section | Display | Purpose |
-|---------|---------|---------|
+| ------- | ------- | ------- |
 | `Highlights` | Condensed (collapsed) view | 1-2 sentences of key accomplishments/impact |
 | `Description` | Expanded view | Context about the role, team, or company |
 | `Details` | Expanded view | Markdown list (`- item`) of detailed responsibilities |

--- a/site/src/pages/cv.astro
+++ b/site/src/pages/cv.astro
@@ -110,7 +110,7 @@ const skills = {
     'DynamoDB',
     'Redis',
     'Kafka',
-    'Clickhouse',
+    'ClickHouse',
     'DuckDB',
   ],
   Observability: ['Prometheus', 'Grafana', 'OpenTelemetry', 'VictoriaMetrics'],


### PR DESCRIPTION
Set up automated code quality checks using hk for git hooks with mise integration. This ensures consistent formatting and linting across the monorepo before commits are made.

- Add hk configuration file with pre-commit hooks for biome and markdownlint
- Configure mise.toml with required tools: hk, pkl, node, and markdownlint-cli
- Update documentation with git hooks installation instructions
- Add setup steps to README for installing tools and hooks
- Update tooling table to include hk for git hooks management

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI lint commands migrated to the mise task runner and lint task suite; new lint task definitions added.
  * Added pre-commit git hooks to run linters on staged files.
  * Introduced mise configuration enabling experimental monorepo support and tool declarations.

* **Documentation**
  * Updated setup and quick-start to include mise and git-hook install steps and linting guidance.
  * Improved site docs formatting and consistency.

* **Content**
  * Normalized ClickHouse capitalization and expanded dictionary entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->