### PR TITLE
feat: add about page content and draft functionality for blog posts

### DIFF
--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -14,6 +14,12 @@ export const SOCIAL_LINKS = {
   linkedin: 'https://linkedin.com/in/ndisidore',
 };
 
+export const HERO_TAGLINE =
+  'I build distributed systems, edge infrastructure, and developer tools. ' +
+  'Currently a founding engineer at Terminal Industries working on computer vision and logistics. ' +
+  'Previously at Cloudflare on the Workers platform and observability systems. ' +
+  'I write about the craft of building software and the tools that make it better.';
+
 // DaisyUI themes - keep in sync with app.css @plugin "daisyui" config
 export const THEMES = [
   { name: 'light', label: 'Light', icon: 'tabler:sun' },

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -30,7 +30,17 @@ const blog = defineCollection({
       heroImage: image().optional(),
       // Tags for categorization
       tags: z.array(z.string()).default([]),
+      // Draft posts are hidden from production
+      draft: z.boolean().default(false),
     }),
+});
+
+const about = defineCollection({
+  loader: glob({ base: './src/content/about', pattern: '*.mdx' }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+  }),
 });
 
 // Role schema for grouped experiences (e.g., multiple roles at one company)
@@ -74,4 +84,4 @@ const experience = defineCollection({
     ),
 });
 
-export const collections = { blog, experience, principles };
+export const collections = { about, blog, experience, principles };

--- a/site/src/content/about/about.mdx
+++ b/site/src/content/about/about.mdx
@@ -1,0 +1,28 @@
+---
+title: About Me
+description: Nathan Disidore - software engineer building distributed systems, edge infrastructure, and developer tools.
+---
+
+I'm Nathan - a software engineer with a computer engineering background and over a decade of experience building systems that scale. I'm drawn to problems at the intersection of infrastructure and developer experience, where good abstractions can make complex things feel simple.
+
+## What I Do
+
+I'm currently a founding engineer at [Terminal Industries](https://terminal-industries.com/), where we're reimagining global shipping and logistics using computer vision and edge computing. I work across the stack - from bootstrapping multi-tenant infrastructure and building Temporal-based workflow engines to managing a fleet of 100+ edge devices with custom observability tooling.
+
+Before Terminal, I spent nearly five years at [Cloudflare](https://cloudflare.com) across three teams. Most recently I worked on [Vectorize](https://developers.cloudflare.com/vectorize/), designing custom vector storage formats for edge-native AI workloads. Before that, I helped build and launch [Workers for Platforms](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/), extending the V8 runtime for multi-tenant execution. I started on the Internal Tools team, where I architected the customer alerting platform and operated Kafka infrastructure processing over a trillion messages daily.
+
+I'm most at home working in Go, Rust, and TypeScript - from distributed backends and workflow engines to developer tooling and frontend. I believe the best infrastructure is invisible: it should get out of the way and let developers focus on what they're building. I'm also interested in how AI can augment development workflows without replacing the satisfaction of building something yourself.
+
+## Interests
+
+When I'm not at the keyboard, I'm probably tinkering with hardware projects on my [custom PC](/uses) or [Framework laptop](/uses), contributing to open source, or throwing discs on a disc golf course. I also enjoy swing dancing when I can find a good venue and the occasional late-night rave.
+
+I'm currently deepening my understanding of distributed systems patterns, exploring the Rust ecosystem for systems programming, and experimenting with local-first software architectures. Always rotating between technical papers and science fiction.
+
+## This Site
+
+This site is built with [Astro](https://astro.build), styled with [Tailwind CSS](https://tailwindcss.com) and [DaisyUI](https://daisyui.com), and hosted on [Cloudflare Workers](https://workers.cloudflare.com). It's an ongoing project - always tweaking the design and adding new sections. Check out [what I'm working on now](/now) or browse my [engineering principles](/principles).
+
+## Contact
+
+The best way to reach me is through [GitHub](https://github.com/ndisidore) or [LinkedIn](https://linkedin.com/in/ndisidore). I'm always up for conversations about distributed systems, developer tools, or interesting engineering challenges.

--- a/site/src/content/blog/first-post.md
+++ b/site/src/content/blog/first-post.md
@@ -4,6 +4,7 @@ description: 'Lorem ipsum dolor sit amet'
 pubDate: 'Jul 08 2022'
 heroImage: '../../assets/blog-placeholder-3.jpg'
 tags: ['getting-started', 'intro']
+draft: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vitae ultricies leo integer malesuada nunc vel risus commodo viverra. Adipiscing enim eu turpis egestas pretium. Euismod elementum nisi quis eleifend quam adipiscing. In hac habitasse platea dictumst vestibulum. Sagittis purus sit amet volutpat. Netus et malesuada fames ac turpis egestas. Eget magna fermentum iaculis eu non diam phasellus vestibulum lorem. Varius sit amet mattis vulputate enim. Habitasse platea dictumst quisque sagittis. Integer quis auctor elit sed vulputate mi. Dictumst quisque sagittis purus sit amet.

--- a/site/src/content/blog/second-post.md
+++ b/site/src/content/blog/second-post.md
@@ -4,6 +4,7 @@ description: 'Lorem ipsum dolor sit amet'
 pubDate: 'Jul 15 2022'
 heroImage: '../../assets/blog-placeholder-4.jpg'
 tags: ['updates', 'development']
+draft: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vitae ultricies leo integer malesuada nunc vel risus commodo viverra. Adipiscing enim eu turpis egestas pretium. Euismod elementum nisi quis eleifend quam adipiscing. In hac habitasse platea dictumst vestibulum. Sagittis purus sit amet volutpat. Netus et malesuada fames ac turpis egestas. Eget magna fermentum iaculis eu non diam phasellus vestibulum lorem. Varius sit amet mattis vulputate enim. Habitasse platea dictumst quisque sagittis. Integer quis auctor elit sed vulputate mi. Dictumst quisque sagittis purus sit amet.

--- a/site/src/content/blog/third-post.md
+++ b/site/src/content/blog/third-post.md
@@ -4,6 +4,7 @@ description: 'Lorem ipsum dolor sit amet'
 pubDate: 'Jul 22 2022'
 heroImage: '../../assets/blog-placeholder-2.jpg'
 tags: ['development', 'coding']
+draft: true
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vitae ultricies leo integer malesuada nunc vel risus commodo viverra. Adipiscing enim eu turpis egestas pretium. Euismod elementum nisi quis eleifend quam adipiscing. In hac habitasse platea dictumst vestibulum. Sagittis purus sit amet volutpat. Netus et malesuada fames ac turpis egestas. Eget magna fermentum iaculis eu non diam phasellus vestibulum lorem. Varius sit amet mattis vulputate enim. Habitasse platea dictumst quisque sagittis. Integer quis auctor elit sed vulputate mi. Dictumst quisque sagittis purus sit amet.

--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -1,51 +1,32 @@
 ---
+import { getCollection, render } from 'astro:content';
 import BaseHead from '../components/BaseHead.astro';
 import Footer from '../components/Footer.astro';
 import Header from '../components/Header.astro';
 import { SITE_TITLE } from '../consts';
+
+const aboutEntries = await getCollection('about');
+if (aboutEntries.length === 0) {
+  throw new Error(
+    "No entries found in 'about' collection. Ensure src/content/about/ contains at least one .mdx file.",
+  );
+}
+const about = aboutEntries[0];
+const { title, description } = about.data;
+const { Content } = await render(about);
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
-    <BaseHead title={`About | ${SITE_TITLE}`} description="Learn more about me" />
+    <BaseHead title={`${title} | ${SITE_TITLE}`} description={description} />
   </head>
   <body class="min-h-screen flex flex-col">
     <Header />
     <main class="container mx-auto px-4 py-8 max-w-4xl flex-1">
-      <h1 class="text-4xl font-bold mb-8">About Me</h1>
-
+      <h1 class="text-4xl font-bold mb-8">{title}</h1>
       <div class="prose prose-lg max-w-none">
-        <p>
-          Write your personal introduction here. Talk about your background, interests, and what
-          you're passionate about.
-        </p>
-
-        <h2>What I Do</h2>
-        <p>
-          Describe your professional work and areas of expertise. Share what drives you and what
-          problems you enjoy solving.
-        </p>
-
-        <h2>Interests</h2>
-        <p>
-          Share your personal interests and hobbies outside of work. This helps visitors connect
-          with you on a personal level.
-        </p>
-
-        <h2>This Site</h2>
-        <p>
-          This site is built with <a href="https://astro.build">Astro</a>, styled with
-          <a href="https://tailwindcss.com">Tailwind CSS</a> and
-          <a href="https://daisyui.com">DaisyUI</a>, and hosted on
-          <a href="https://workers.cloudflare.com">Cloudflare Workers</a>.
-        </p>
-
-        <h2>Contact</h2>
-        <p>
-          Feel free to reach out to me on social media or via email. I'm always happy to chat about
-          technology, projects, or potential collaborations.
-        </p>
+        <Content />
       </div>
     </main>
     <Footer />

--- a/site/src/pages/blog/[...slug].astro
+++ b/site/src/pages/blog/[...slug].astro
@@ -4,9 +4,9 @@ import BlogPost from '../../layouts/BlogPost.astro';
 import { calculateReadingTime } from '../../utils/reading-time';
 
 export async function getStaticPaths() {
-  const posts = (await getCollection('blog')).sort(
-    (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
-  );
+  const posts = (await getCollection('blog'))
+    .filter((post) => !post.data.draft)
+    .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
   return posts.map((post, index) => ({
     params: { slug: post.id },

--- a/site/src/pages/blog/index.astro
+++ b/site/src/pages/blog/index.astro
@@ -10,9 +10,9 @@ import TagList from '../../components/TagList.astro';
 import { SITE_TITLE } from '../../consts';
 import { getTagCounts } from '../../utils/tags';
 
-const posts = (await getCollection('blog')).sort(
-  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
-);
+const posts = (await getCollection('blog'))
+  .filter((post) => !post.data.draft)
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
 const tagCounts = getTagCounts(posts);
 const sortedTags = Array.from(tagCounts.entries()).sort((a, b) => b[1] - a[1]);

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -9,9 +9,16 @@ import Footer from '../components/Footer.astro';
 import FormattedDate from '../components/FormattedDate.astro';
 import Header from '../components/Header.astro';
 import TagList from '../components/TagList.astro';
-import { ME, SITE_DESCRIPTION, SITE_TITLE, SOCIAL_LINKS } from '../consts';
+import {
+  HERO_TAGLINE,
+  ME,
+  SITE_DESCRIPTION,
+  SITE_TITLE,
+  SOCIAL_LINKS,
+} from '../consts';
 
 const recentPosts = (await getCollection('blog'))
+  .filter((post) => !post.data.draft)
   .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
   .slice(0, 4);
 ---
@@ -45,8 +52,7 @@ const recentPosts = (await getCollection('blog'))
           <div class="max-w-2xl text-center lg:text-left">
             <h1 class="text-4xl md:text-5xl font-bold">Hi, I'm {ME}</h1>
             <p class="py-6 text-lg text-base-content/80">
-              A brief introduction about yourself. What you do, what you're passionate about, and
-              what visitors can expect to find on your site.
+              {HERO_TAGLINE}
             </p>
 
             <!-- Social Links -->

--- a/site/src/pages/tags/[tag].astro
+++ b/site/src/pages/tags/[tag].astro
@@ -9,7 +9,9 @@ import { SITE_TITLE } from '../../consts';
 import { getAllTags, getPostsByTag } from '../../utils/tags';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('blog');
+  const posts = (await getCollection('blog')).filter(
+    (post) => !post.data.draft,
+  );
   const tags = getAllTags(posts);
 
   return tags.map((tag) => ({


### PR DESCRIPTION
Add comprehensive about page content using content collections and implement draft post functionality to hide placeholder content from production.

- Add HERO_TAGLINE constant with professional introduction text
- Create about collection with MDX support for structured content management
- Add draft field to blog schema to control post visibility
- Implement about.mdx with detailed professional background and experience
- Filter draft posts from all blog displays and static path generation
- Mark existing placeholder blog posts as drafts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Created an About page with comprehensive biographical information, professional background, technical skills, and contact details
  * Enhanced the homepage with a dynamic hero tagline

* **Improvements**
  * Draft blog posts are now automatically excluded from blog listings and tag pages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->