### PR TITLE
docs: add neobrutalism design system documentation

### DIFF
--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -42,7 +42,7 @@ Extensive theming support via DaisyUI. Theme persistence uses localStorage with 
 
 ### Neobrutalism Design
 
-The site uses a neobrutalism aesthetic applied globally via `src/styles/app.css`. Key characteristics: bold 2px borders, offset box shadows (4px), and hover states that shift elements. Design tokens in `@theme` include `--neo-shadow`, `--neo-shadow-hover`, and `--neo-border` for consistency across components (buttons, cards, inputs, dropdowns, navbar).
+The site uses a neobrutalism aesthetic applied globally via `src/styles/app.css`. Key characteristics: bold 2px borders, offset box shadows (4px), and hover states that shift elements. Design tokens in `@theme` include `--neo-shadow` (4px), `--neo-shadow-sm` (3px), `--neo-shadow-hover` (2px), and `--neo-border` for consistency across components (buttons, cards, inputs, dropdowns, navbar).
 
 ### Icons
 

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -40,6 +40,10 @@ Tags have dedicated filter pages at `/tags/[tag]`. Tag utilities are in `src/uti
 
 Extensive theming support via DaisyUI. Theme persistence uses localStorage with system preference fallback. The `ThemeToggle.astro` component handles switching. FOUC is prevented by an inline script in `BaseHead.astro` that sets the theme before render.
 
+### Neobrutalism Design
+
+The site uses a neobrutalism aesthetic applied globally via `src/styles/app.css`. Key characteristics: bold 2px borders, offset box shadows (4px), and hover states that shift elements. Design tokens in `@theme` include `--neo-shadow`, `--neo-shadow-hover`, and `--neo-border` for consistency across components (buttons, cards, inputs, dropdowns, navbar).
+
 ### Icons
 
 Icons use [Iconify](https://iconify.design/) via `astro-icon`. Three icon sets are installed:

--- a/site/biome.json
+++ b/site/biome.json
@@ -61,6 +61,15 @@
     "parser": {
       "cssModules": true,
       "tailwindDirectives": true
+    },
+    "formatter": {
+      "enabled": true,
+      "indentStyle": "space",
+      "indentWidth": 2,
+      "quoteStyle": "double"
+    },
+    "linter": {
+      "enabled": true
     }
   },
   "assist": {

--- a/site/src/pages/uses.astro
+++ b/site/src/pages/uses.astro
@@ -201,7 +201,7 @@ function getSpanClasses(span?: 'wide' | 'tall' | 'large'): string {
         {
           categories.map((category, index) => (
             <div
-              class={`card bg-base-100 shadow-xl group hover:shadow-2xl transition-all duration-300 animate-on-scroll ${getSpanClasses(category.span)}`}
+              class={`card bg-base-100 animate-on-scroll ${getSpanClasses(category.span)}`}
               style={`--delay: ${index * 100}ms`}
             >
               <div class="card-body">

--- a/site/src/styles/app.css
+++ b/site/src/styles/app.css
@@ -46,6 +46,22 @@
 /* Theme customization */
 @theme {
   --font-sans: "Atkinson", ui-sans-serif, system-ui, sans-serif;
+
+  /* Content opacity variants using color-mix */
+  --content-80: color-mix(in oklch, var(--color-base-content) 80%, transparent);
+  --content-70: color-mix(in oklch, var(--color-base-content) 70%, transparent);
+  --content-50: color-mix(in oklch, var(--color-base-content) 50%, transparent);
+  --content-40: color-mix(in oklch, var(--color-base-content) 40%, transparent);
+  --content-30: color-mix(in oklch, var(--color-base-content) 30%, transparent);
+  --content-20: color-mix(in oklch, var(--color-base-content) 20%, transparent);
+  --content-12: color-mix(in oklch, var(--color-base-content) 12%, transparent);
+  --neutral-6: color-mix(in oklch, var(--color-neutral) 6%, transparent);
+
+  /* Neobrutalism design tokens */
+  --neo-shadow: 4px 4px 0 0;
+  --neo-shadow-sm: 3px 3px 0 0;
+  --neo-shadow-hover: 2px 2px 0 0;
+  --neo-border: 2px solid;
 }
 
 /* Base styles */
@@ -62,54 +78,22 @@ html {
 .prose {
   --tw-prose-body: var(--color-base-content);
   --tw-prose-headings: var(--color-base-content);
-  --tw-prose-lead: color-mix(
-    in oklch,
-    var(--color-base-content) 80%,
-    transparent
-  );
+  --tw-prose-lead: var(--content-80);
   --tw-prose-links: var(--color-primary);
   --tw-prose-bold: var(--color-base-content);
-  --tw-prose-counters: color-mix(
-    in oklch,
-    var(--color-base-content) 70%,
-    transparent
-  );
-  --tw-prose-bullets: color-mix(
-    in oklch,
-    var(--color-base-content) 50%,
-    transparent
-  );
-  --tw-prose-hr: color-mix(
-    in oklch,
-    var(--color-base-content) 20%,
-    transparent
-  );
+  --tw-prose-counters: var(--content-70);
+  --tw-prose-bullets: var(--content-50);
+  --tw-prose-hr: var(--content-20);
   --tw-prose-quotes: var(--color-base-content);
   --tw-prose-quote-borders: var(--color-primary);
-  --tw-prose-captions: color-mix(
-    in oklch,
-    var(--color-base-content) 70%,
-    transparent
-  );
+  --tw-prose-captions: var(--content-70);
   --tw-prose-kbd: var(--color-base-content);
-  --tw-prose-kbd-shadows: color-mix(
-    in oklch,
-    var(--color-base-content) 30%,
-    transparent
-  );
+  --tw-prose-kbd-shadows: var(--content-30);
   --tw-prose-code: var(--color-base-content);
   --tw-prose-pre-code: var(--color-base-content);
   --tw-prose-pre-bg: var(--color-base-200);
-  --tw-prose-th-borders: color-mix(
-    in oklch,
-    var(--color-base-content) 30%,
-    transparent
-  );
-  --tw-prose-td-borders: color-mix(
-    in oklch,
-    var(--color-base-content) 20%,
-    transparent
-  );
+  --tw-prose-th-borders: var(--content-30);
+  --tw-prose-td-borders: var(--content-20);
 }
 
 .prose a {
@@ -131,14 +115,14 @@ html {
 }
 
 .prose hr {
-  border-color: color-mix(in oklch, var(--color-base-content) 20%, transparent);
+  border-color: var(--content-20);
 }
 
 /* Code blocks */
 .prose pre {
   background-color: var(--color-base-200);
-  border: 2px solid var(--color-neutral);
-  box-shadow: 4px 4px 0 0 var(--color-neutral);
+  border: var(--neo-border) var(--color-neutral);
+  box-shadow: var(--neo-shadow) var(--color-neutral);
   border-radius: 0.5rem;
   padding: 1rem;
   overflow-x: auto;
@@ -170,8 +154,7 @@ html {
 
 .prose th,
 .prose td {
-  border: 1px solid
-    color-mix(in oklch, var(--color-base-content) 20%, transparent);
+  border: 1px solid var(--content-20);
   padding: 0.5rem 1rem;
 }
 
@@ -191,18 +174,16 @@ pre[data-line-numbers] code .line::before {
   width: 2rem;
   margin-right: 1rem;
   text-align: right;
-  color: color-mix(in oklch, var(--color-base-content) 40%, transparent);
+  color: var(--content-40);
 }
 
 /* Shiki theme switching */
-html[data-theme="light"] .shiki,
-html[data-theme="light"] .shiki span {
+:is(html[data-theme="light"]) :is(.shiki, .shiki span) {
   color: var(--shiki-light) !important;
   background-color: var(--shiki-light-bg) !important;
 }
 
-html[data-theme="dracula"] .shiki,
-html[data-theme="dracula"] .shiki span {
+:is(html[data-theme="dracula"]) :is(.shiki, .shiki span) {
   color: var(--shiki-dark) !important;
   background-color: var(--shiki-dark-bg) !important;
 }
@@ -211,19 +192,6 @@ html[data-theme="dracula"] .shiki span {
 .toc-link.active {
   background-color: var(--color-primary);
   color: var(--color-primary-content);
-}
-
-/* Screen reader only utility */
-.sr-only {
-  position: absolute !important;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
 }
 
 /* Timeline customizations for CV */
@@ -239,16 +207,14 @@ html[data-theme="dracula"] .shiki span {
 
 /* Buttons */
 .btn {
-  border: 2px solid currentColor;
-  box-shadow: 4px 4px 0 0 currentColor;
-  transition:
-    transform 0.15s ease,
-    box-shadow 0.15s ease;
+  border: var(--neo-border) currentColor;
+  box-shadow: var(--neo-shadow) currentColor;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
 .btn:hover {
   transform: translate(2px, 2px);
-  box-shadow: 2px 2px 0 0 currentColor;
+  box-shadow: var(--neo-shadow-hover) currentColor;
 }
 
 .btn:active {
@@ -258,76 +224,71 @@ html[data-theme="dracula"] .shiki span {
 
 /* Cards */
 .card {
-  border: 2px solid var(--color-base-content);
-  box-shadow: 4px 4px 0 0 var(--color-base-content);
-  transition:
-    transform 0.15s ease,
-    box-shadow 0.15s ease;
+  border: var(--neo-border) var(--color-base-content);
+  box-shadow: var(--neo-shadow) var(--color-base-content);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
 .card:hover {
   transform: translate(2px, 2px);
-  box-shadow: 2px 2px 0 0 var(--color-base-content);
+  box-shadow: var(--neo-shadow-hover) var(--color-base-content);
 }
 
 /* Badges */
 .badge {
-  border: 2px solid currentColor;
-  border-radius: 0.375rem; /* rounded-md */
+  border: var(--neo-border) currentColor;
+  border-radius: 0.375rem;
 }
 
 /* Form inputs */
 .input,
 .textarea,
 .select {
-  border: 2px solid var(--color-base-content);
+  border: var(--neo-border) var(--color-base-content);
   transition: box-shadow 0.15s ease;
 }
 
 .input:focus,
 .textarea:focus,
 .select:focus {
-  box-shadow: 4px 4px 0 0 var(--color-primary);
+  box-shadow: var(--neo-shadow) var(--color-primary);
 }
 
 /* Dropdowns */
 .dropdown-content {
-  border: 2px solid var(--color-base-content);
-  box-shadow: 4px 4px 0 0 var(--color-base-content);
+  border: var(--neo-border) var(--color-base-content);
+  box-shadow: var(--neo-shadow) var(--color-base-content);
 }
 
 /* Table of Contents menu */
 .toc .menu {
-  border: 2px solid var(--color-base-content);
-  box-shadow: 4px 4px 0 0 var(--color-base-content);
+  border: var(--neo-border) var(--color-base-content);
+  box-shadow: var(--neo-shadow) var(--color-base-content);
   border-radius: 0.5rem;
 }
 
 /* Navbar */
 .navbar {
-  border-bottom: 2px solid var(--color-base-content);
+  border-bottom: var(--neo-border) var(--color-base-content);
 }
 
 /* Navbar menu items */
 .navbar .menu-horizontal > li > a,
 .navbar .menu-horizontal > li > [role="button"] {
-  border: 2px solid transparent;
+  border: var(--neo-border) transparent;
   border-radius: 0.375rem;
-  transition:
-    border-color 0.15s ease,
-    box-shadow 0.15s ease,
-    transform 0.15s ease;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
 }
 
 .navbar .menu-horizontal > li > a:hover,
 .navbar .menu-horizontal > li > [role="button"]:hover {
   border-color: var(--color-base-content);
-  box-shadow: 2px 2px 0 0 var(--color-base-content);
+  box-shadow: var(--neo-shadow-hover) var(--color-base-content);
 }
 
 .navbar .menu-horizontal > li > a.menu-active {
   border-color: var(--color-base-content);
-  box-shadow: 3px 3px 0 0 var(--color-base-content);
+  box-shadow: var(--neo-shadow-sm) var(--color-base-content);
 }
 
 /* Smooth page transitions */
@@ -364,8 +325,8 @@ html[data-theme="dracula"] .shiki span {
   inset: 0;
   background: radial-gradient(
     260px circle at var(--mouse-x) var(--mouse-y),
-    color-mix(in oklch, var(--color-base-content) 12%, transparent),
-    color-mix(in oklch, var(--color-neutral) 6%, transparent) 50%,
+    var(--content-12),
+    var(--neutral-6) 50%,
     transparent 80%
   );
   pointer-events: none;

--- a/site/src/styles/app.css
+++ b/site/src/styles/app.css
@@ -209,7 +209,9 @@ pre[data-line-numbers] code .line::before {
 .btn {
   border: var(--neo-border) currentColor;
   box-shadow: var(--neo-shadow) currentColor;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
 .btn:hover {
@@ -226,7 +228,9 @@ pre[data-line-numbers] code .line::before {
 .card {
   border: var(--neo-border) var(--color-base-content);
   box-shadow: var(--neo-shadow) var(--color-base-content);
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
 .card:hover {
@@ -277,7 +281,10 @@ pre[data-line-numbers] code .line::before {
 .navbar .menu-horizontal > li > [role="button"] {
   border: var(--neo-border) transparent;
   border-radius: 0.375rem;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
 }
 
 .navbar .menu-horizontal > li > a:hover,


### PR DESCRIPTION
Document the neobrutalism aesthetic implementation with design tokens for borders, shadows, and hover states. Update uses page to simplify card styling by removing redundant shadow classes.

- Add design system documentation for neobrutalism aesthetic in CLAUDE.md
- Define CSS design tokens for consistent neo styling (--neo-shadow, --neo-border)
- Create content opacity variants using color-mix for better maintainability
- Refactor prose styles to use new design tokens
- Simplify card hover effects on uses page
- Improve CSS selector specificity for Shiki themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Neobrutalism aesthetic sitewide with bold borders, offset shadows, and hover shifts for a distinctive look.

* **Style**
  * Centralized design tokens for colors, shadows, borders, and transitions; updated component hover/focus behavior and reduced duplicated inline styling.
  * Adjusted card/interaction styles to simplify hover effects.

* **Documentation**
  * Added Neobrutalism design guidance and token specifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->