### PR TITLE
feat: update site branding and header title

### DIFF
--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -2,7 +2,7 @@
 import { Image } from 'astro:assets';
 import { Icon } from 'astro-icon/components';
 import avatar from '../assets/logos/diz-rocks-avatar.svg';
-import { SITE_TITLE, SOCIAL_LINKS } from '../consts';
+import { SOCIAL_LINKS } from '../consts';
 import HeaderLink from './HeaderLink.astro';
 import ThemeToggle from './ThemeToggle.astro';
 
@@ -65,7 +65,7 @@ const aboutItems = [
     </div>
     <a href="/" class="btn btn-ghost text-xl gap-2">
       <Image src={avatar} alt="" class="w-8 h-8" />
-      {SITE_TITLE}
+      Rock Out
     </a>
   </div>
 

--- a/site/src/consts.ts
+++ b/site/src/consts.ts
@@ -1,9 +1,9 @@
 // Place any global data in this file.
 // You can import this data from anywhere in your site by using the `import` keyword.
 
-export const SITE_TITLE = 'Diz.Rocks';
+export const SITE_TITLE = 'Diz Rocks — Work, Play, and Occasional Brilliance';
 export const SITE_DESCRIPTION =
-  'Personal website and blog about software development, technology, and more.';
+  'A tiny rock on the web for my experiments in code, dev tools, and strange ideas that somehow ship';
 
 export const SITE_URL = 'https://diz.rocks';
 export const ME = 'Nathan Disidore';


### PR DESCRIPTION
Replace dynamic site title with hardcoded "Rock Out" branding and refresh the site's tagline and description to better reflect the personal nature of the website and its focus on development experiments.

• Remove SITE_TITLE import and usage from Header component
• Replace header title with static "Rock Out" text
• Update SITE_TITLE constant to include full tagline
• Revise SITE_DESCRIPTION to emphasize experimental development content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed website branding with an updated title and tagline that better represents the site's core mission and creative focus.
  * Revised website description to highlight the site's dedication to code experiments, development tools, and innovative projects.
  * Enhanced header branding display for improved visibility and consistency throughout the site.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->