### PR TITLE
ci: add automated deployment workflow for cloudflare workers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    defaults:
+      run:
+        working-directory: site
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Install mise
+        uses: jdx/mise-action@v3
+        with:
+          working_directory: site
+
+      - name: Deploy to Cloudflare Workers
+        run: mise run ci:deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
Adds GitHub Actions workflow to automatically deploy the site to Cloudflare Workers after successful CI runs on the main branch.

• Deploy workflow triggers after successful CI completion on main branch
• Uses concurrency control to prevent multiple simultaneous deployments
• Installs mise and executes deployment script with Cloudflare API token
• Runs deployment commands from the site working directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated deployment workflow that runs after successful CI on main.
  * Deployment includes concurrency safeguards to cancel in-progress deployments and uses a stored secret to publish the site.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->