### PR TITLE
feat: add code block enhancements with filename and caption support

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -6,6 +6,8 @@ import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'astro/config';
 import icon from 'astro-icon';
+import remarkDirective from 'remark-directive';
+import remarkCodeFigure from './src/plugins/remark-code-figure';
 
 // https://astro.build/config
 export default defineConfig({
@@ -22,6 +24,7 @@ export default defineConfig({
     plugins: [tailwindcss()],
   },
   markdown: {
+    remarkPlugins: [remarkDirective, remarkCodeFigure],
     shikiConfig: {
       themes: {
         light: 'github-light',

--- a/site/biome.json
+++ b/site/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -17,14 +17,19 @@
         "@iconify-json/tabler": "^1.2.26",
         "astro": "^5.16.11",
         "astro-icon": "^1.1.5",
-        "sharp": "^0.34.5"
+        "remark-directive": "^4.0.0",
+        "sharp": "^0.34.5",
+        "unist-util-visit": "^5.1.0"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.11",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.1.18",
+        "@types/mdast": "^4.0.4",
         "@types/node": "^25.0.9",
+        "@types/unist": "^3.0.3",
         "daisyui": "^5.5.14",
+        "mdast-util-directive": "^3.1.0",
         "tailwindcss": "^4.1.18",
         "wrangler": "^4.59.3"
       }
@@ -1142,7 +1147,6 @@
       "integrity": "sha512-Om5ns0Lyx/LKtYI04IV0bjIrkBgoFNg0p6urzr2asekJlfP18RqFzyqMFZKf0i9Gnjtz/JfAS/Ol6tjCe5JJsQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -1661,8 +1665,7 @@
       "version": "4.20260120.0",
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260120.0.tgz",
       "integrity": "sha512-B8pueG+a5S+mdK3z8oKu1ShcxloZ7qWb68IEyLLaepvdryIbNC7JVPcY0bWsjS56UQVKc5fnyRge3yZIwc9bxw==",
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -3694,7 +3697,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
       "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3735,7 +3737,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3905,7 +3906,6 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.16.15.tgz",
       "integrity": "sha512-+X1Z0NTi2pa5a0Te6h77Dgc44fYj63j1yx6+39Nvg05lExajxSq7b1Uj/gtY45zoum8fD0+h0nak+DnHighs3A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.5",
@@ -5597,7 +5597,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -5635,7 +5634,6 @@
       "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
       "devOptional": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -5978,6 +5976,27 @@
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",
         "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-directive": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
+      "integrity": "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-visit-parents": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6344,6 +6363,25 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -7689,6 +7727,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-4.0.0.tgz",
+      "integrity": "sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-directive": "^3.0.0",
+        "micromark-extension-directive": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -8190,8 +8244,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -8365,7 +8418,6 @@
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -8495,9 +8547,9 @@
       }
     },
     "node_modules/unist-util-visit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -8770,6 +8822,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8787,6 +8840,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8804,6 +8858,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8821,6 +8876,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8838,6 +8894,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8855,6 +8912,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8872,6 +8930,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8889,6 +8948,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8906,6 +8966,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8923,6 +8984,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8940,6 +9002,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8957,6 +9020,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8974,6 +9038,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8991,6 +9056,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9008,6 +9074,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9025,6 +9092,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9042,6 +9110,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9059,6 +9128,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9076,6 +9146,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9093,6 +9164,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9110,6 +9182,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9127,6 +9200,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9144,6 +9218,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9161,6 +9236,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9178,6 +9254,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9195,6 +9272,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9206,6 +9284,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -9323,7 +9402,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -10002,7 +10080,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/site/package.json
+++ b/site/package.json
@@ -26,14 +26,19 @@
     "@iconify-json/tabler": "^1.2.26",
     "astro": "^5.16.11",
     "astro-icon": "^1.1.5",
-    "sharp": "^0.34.5"
+    "remark-directive": "^4.0.0",
+    "sharp": "^0.34.5",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.11",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.1.18",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^25.0.9",
+    "@types/unist": "^3.0.3",
     "daisyui": "^5.5.14",
+    "mdast-util-directive": "^3.1.0",
     "tailwindcss": "^4.1.18",
     "wrangler": "^4.59.3"
   }

--- a/site/src/content/blog/markdown-style-guide.md
+++ b/site/src/content/blog/markdown-style-guide.md
@@ -129,6 +129,59 @@ we can use 3 backticks ``` in new line and write snippet and close with 3 backti
 </html>
 ```
 
+### Code Block with Caption
+
+Use `:::caption` after a code block to add a caption with full markdown support:
+
+```js
+const response = await fetch('/api/data');
+const data = await response.json();
+```
+
+:::caption
+Uses the [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/fetch) API with **async/await** syntax.
+:::
+
+### Code Block with Filename
+
+Use `:::filename` before a code block to show the file path:
+
+:::filename
+src/utils/api.js
+:::
+
+```js
+export async function fetchData(endpoint) {
+  return fetch(endpoint).then((r) => r.json());
+}
+```
+
+### Code Block with Both
+
+Combine both for complete context:
+
+:::filename
+src/components/UserCard.astro
+:::
+
+```astro
+---
+interface Props {
+  name: string;
+  email: string;
+}
+const { name, email } = Astro.props;
+---
+<div class="card">
+  <h2>{name}</h2>
+  <p>{email}</p>
+</div>
+```
+
+:::caption
+An [Astro component](https://docs.astro.build/en/basics/astro-components/) that renders a user card with _typed props_.
+:::
+
 ## List Types
 
 ### Ordered List

--- a/site/src/plugins/remark-code-figure.ts
+++ b/site/src/plugins/remark-code-figure.ts
@@ -1,0 +1,80 @@
+/**
+ * Remark plugin to wrap code blocks with figure/figcaption for captions and filenames.
+ *
+ * Syntax:
+ *   :::filename
+ *   path/to/file.js
+ *   :::
+ *
+ *   ```js
+ *   code here
+ *   ```
+ *
+ *   :::caption
+ *   Caption with **markdown** and [links](url).
+ *   :::
+ */
+
+import type { Root, Parent, RootContent, PhrasingContent } from 'mdast';
+import type { ContainerDirective } from 'mdast-util-directive';
+
+type Directive = ContainerDirective & RootContent;
+
+function processParent(parent: Parent) {
+  // Process in reverse to avoid index-shifting issues when splicing
+  for (let i = parent.children.length - 1; i >= 0; i--) {
+    const node = parent.children[i];
+
+    // Recurse into nested structures (blockquotes, list items, etc.)
+    if ('children' in node) processParent(node as Parent);
+
+    if (node.type !== 'code') continue;
+
+    const prev = parent.children[i - 1] as Directive | undefined;
+    const next = parent.children[i + 1] as Directive | undefined;
+    const hasFilename =
+      prev?.type === 'containerDirective' && prev.name === 'filename';
+    const hasCaption =
+      next?.type === 'containerDirective' && next.name === 'caption';
+
+    if (!hasFilename && !hasCaption) continue;
+
+    // Build figure children
+    const children: RootContent[] = [];
+
+    if (hasFilename) {
+      children.push({
+        type: 'paragraph',
+        data: { hName: 'div', hProperties: { className: ['code-filename'] } },
+        children: prev.children.flatMap((c) =>
+          c.type === 'paragraph' ? c.children : [],
+        ) as PhrasingContent[],
+      } as RootContent);
+    }
+
+    children.push(node);
+
+    if (hasCaption) {
+      children.push({
+        type: 'paragraph',
+        data: { hName: 'figcaption' },
+        children: next.children.flatMap((c) =>
+          c.type === 'paragraph' ? c.children : [],
+        ) as PhrasingContent[],
+      } as RootContent);
+    }
+
+    // Replace the directive(s) + code block with the figure
+    const start = hasFilename ? i - 1 : i;
+    const count = 1 + (hasFilename ? 1 : 0) + (hasCaption ? 1 : 0);
+    parent.children.splice(start, count, {
+      type: 'paragraph',
+      data: { hName: 'figure', hProperties: { className: ['code-figure'] } },
+      children,
+    } as RootContent);
+  }
+}
+
+export default function remarkCodeFigure() {
+  return (tree: Root) => processParent(tree);
+}

--- a/site/src/styles/app.css
+++ b/site/src/styles/app.css
@@ -61,9 +61,14 @@
   --neo-offset: 4px;
   --neo-shadow: var(--neo-offset) var(--neo-offset) 0 0;
   --neo-shadow-sm: 3px 3px 0 0;
-  --neo-shadow-hover:
-    calc(var(--neo-offset) / 2) calc(var(--neo-offset) / 2) 0, 0;
+  --neo-shadow-hover: calc(var(--neo-offset) / 2) calc(var(--neo-offset) / 2) 0
+    0;
   --neo-border: 2px solid;
+  --neo-radius: 0.5rem;
+  --neo-radius-sm: 0.375rem;
+  --neo-radius-xs: 0.25rem;
+  --neo-transition: 0.15s ease;
+  --neo-font-sm: 0.875rem;
 }
 
 /* Base styles */
@@ -125,16 +130,56 @@ html {
   background-color: var(--color-base-200);
   border: var(--neo-border) var(--color-neutral);
   box-shadow: var(--neo-shadow) var(--color-neutral);
-  border-radius: 0.5rem;
+  border-radius: var(--neo-radius);
   padding: 1rem;
   overflow-x: auto;
+}
+
+/* Code figure (code blocks with filename/caption) */
+.prose figure.code-figure {
+  margin: 1.5rem 0;
+  border: var(--neo-border) var(--color-neutral);
+  border-radius: var(--neo-radius);
+  box-shadow: var(--neo-shadow) var(--color-neutral);
+  overflow: hidden;
+}
+
+.prose figure.code-figure pre {
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.prose .code-filename,
+.prose figure.code-figure figcaption {
+  font-size: var(--neo-font-sm);
+  padding: 0.5rem 1rem;
+  color: var(--tw-prose-captions);
+}
+
+.prose .code-filename {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  background-color: var(--color-base-300);
+  border-bottom: var(--neo-border) var(--color-neutral);
+}
+
+.prose figure.code-figure figcaption {
+  margin-top: 0;
+  padding: 0.75rem 1rem;
+  background-color: var(--color-base-200);
+  border-top: var(--neo-border) var(--color-neutral);
+}
+
+.prose figure.code-figure figcaption p {
+  margin: 0;
 }
 
 .prose :not(pre) > code {
   background-color: var(--color-base-200);
   border: 1px solid var(--color-neutral);
   padding: 0.125rem 0.375rem;
-  border-radius: 0.25rem;
+  border-radius: var(--neo-radius-xs);
   font-size: 0.875em;
 }
 
@@ -212,8 +257,8 @@ pre[data-line-numbers] code .line::before {
   border: var(--neo-border) currentColor;
   box-shadow: var(--neo-shadow) currentColor;
   transition:
-    transform 0.15s ease,
-    box-shadow 0.15s ease;
+    transform var(--neo-transition),
+    box-shadow var(--neo-transition);
 }
 
 .btn:hover {
@@ -235,8 +280,8 @@ pre[data-line-numbers] code .line::before {
   box-shadow: var(--neo-shadow) var(--color-base-content);
   overflow: hidden;
   transition:
-    transform 0.15s ease,
-    box-shadow 0.15s ease;
+    transform var(--neo-transition),
+    box-shadow var(--neo-transition);
 }
 
 .card figure {
@@ -251,12 +296,10 @@ pre[data-line-numbers] code .line::before {
 .card-pressable::before {
   content: "";
   position: absolute;
-  top: var(--neo-offset);
-  left: var(--neo-offset);
-  right: calc(-1 * var(--neo-offset));
-  bottom: calc(-1 * var(--neo-offset));
+  inset: var(--neo-offset) calc(-1 * var(--neo-offset))
+    calc(-1 * var(--neo-offset)) var(--neo-offset);
   background: var(--color-base-content);
-  border-radius: var(--radius-box, 0.5rem);
+  border-radius: var(--radius-box, var(--neo-radius));
   z-index: 0;
 }
 
@@ -265,7 +308,7 @@ pre[data-line-numbers] code .line::before {
   z-index: 1;
   box-shadow: none;
   cursor: pointer;
-  transition: transform 0.15s ease;
+  transition: transform var(--neo-transition);
 }
 
 .card-pressable:hover > .card {
@@ -282,7 +325,7 @@ pre[data-line-numbers] code .line::before {
 /* Badges */
 .badge {
   border: var(--neo-border) currentColor;
-  border-radius: 0.375rem;
+  border-radius: var(--neo-radius-sm);
 }
 
 /* Form inputs */
@@ -290,7 +333,7 @@ pre[data-line-numbers] code .line::before {
 .textarea,
 .select {
   border: var(--neo-border) var(--color-base-content);
-  transition: box-shadow 0.15s ease;
+  transition: box-shadow var(--neo-transition);
 }
 
 .input:focus,
@@ -299,17 +342,15 @@ pre[data-line-numbers] code .line::before {
   box-shadow: var(--neo-shadow) var(--color-primary);
 }
 
-/* Dropdowns */
-.dropdown-content {
+/* Dropdowns & TOC menu - shared neo box style */
+.dropdown-content,
+.toc .menu {
   border: var(--neo-border) var(--color-base-content);
   box-shadow: var(--neo-shadow) var(--color-base-content);
 }
 
-/* Table of Contents menu */
 .toc .menu {
-  border: var(--neo-border) var(--color-base-content);
-  box-shadow: var(--neo-shadow) var(--color-base-content);
-  border-radius: 0.5rem;
+  border-radius: var(--neo-radius);
 }
 
 /* Navbar */
@@ -318,18 +359,16 @@ pre[data-line-numbers] code .line::before {
 }
 
 /* Navbar menu items */
-.navbar .menu-horizontal > li > a,
-.navbar .menu-horizontal > li > [role="button"] {
+.navbar .menu-horizontal > li > :is(a, [role="button"]) {
   border: var(--neo-border) transparent;
-  border-radius: 0.375rem;
+  border-radius: var(--neo-radius-sm);
   transition:
-    border-color 0.15s ease,
-    box-shadow 0.15s ease,
-    transform 0.15s ease;
+    border-color var(--neo-transition),
+    box-shadow var(--neo-transition),
+    transform var(--neo-transition);
 }
 
-.navbar .menu-horizontal > li > a:hover,
-.navbar .menu-horizontal > li > [role="button"]:hover {
+.navbar .menu-horizontal > li > :is(a, [role="button"]):hover {
   border-color: var(--color-base-content);
   box-shadow: var(--neo-shadow-hover) var(--color-base-content);
 }
@@ -392,7 +431,6 @@ pre[data-line-numbers] code .line::before {
   z-index: 1;
 }
 
-/* Disable on touch devices for performance */
 @media (hover: none) {
   .hero-interactive::before {
     display: none;


### PR DESCRIPTION
Adds remark plugin to enhance code blocks with filename headers and captions using markdown directives. This provides better context for code examples by allowing file paths and explanatory text with full markdown support.

- Add remark-directive and custom remark-code-figure plugin
- Support :::filename and :::caption directives around code blocks
- Include CSS styles for enhanced code figure presentation
- Update dependencies for AST manipulation and markdown processing
- Add example usage to markdown style guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown code blocks now support optional filenames and captions, rendered as unified code figures.

* **Documentation**
  * Added examples demonstrating filename, caption, and combined code-block usage in the style guide.

* **Style**
  * Introduced design tokens for radii, transitions, and typography; updated styles for code figures, cards, nav, badges, and inputs for consistent visuals.

* **Chores**
  * Updated build/config to enable the new Markdown processing and added related tooling dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->