### PR TITLE
feat: add preview environment deployment for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   lint:
     name: Lint
@@ -41,3 +45,80 @@ jobs:
         # Allow grammar warnings during initial CV content rollout
         continue-on-error: true
         run: ./scripts/grammar-check.sh src/content/cv/experience/*.mdx
+
+  preview:
+    name: Deploy Preview
+    runs-on: ubuntu-latest
+    needs: lint
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+    defaults:
+      run:
+        working-directory: site
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install mise
+        uses: jdx/mise-action@v3
+        with:
+          working_directory: site
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Upload preview version
+        run: npx wrangler versions upload --preview-alias "pr-${{ github.event.pull_request.number }}"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: Post preview URL comment
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: https://pr-${{ github.event.pull_request.number }}-hq.diz.workers.dev
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const { PREVIEW_URL, COMMIT_SHA } = process.env;
+            const shortSha = COMMIT_SHA.substring(0, 7);
+            const marker = '<!-- cf-preview -->';
+            const body = `${marker}
+            ## 🚀 Preview Ready
+
+            Your changes have been deployed to a preview environment.
+
+            | | |
+            |---|---|
+            | **Preview URL** | ${PREVIEW_URL} |
+            | **Commit** | \`${shortSha}\` |
+
+            > [!NOTE]
+            > This preview will be updated on each push to this PR.
+            `;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body
+              });
+            }

--- a/site/wrangler.jsonc
+++ b/site/wrangler.jsonc
@@ -9,6 +9,7 @@
   "main": "./dist/_worker.js/index.js",
   "compatibility_date": "2025-12-25",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+  "preview_urls": true,
   "routes": [
     { "pattern": "diz.rocks/*", "zone_id": "e8dc8fdeca28d9fe0fecf68eb5659916" },
     {


### PR DESCRIPTION
Implements automated preview deployments using Cloudflare Versions to enable testing changes before merging. Adds GitHub permissions and bot commenting functionality to streamline the review process.

- Add preview job that deploys to Cloudflare Versions with PR-specific alias
- Configure GitHub permissions for reading contents and writing PR comments
- Implement automated commenting with preview URL and commit information
- Enable preview URLs in Wrangler configuration for Cloudflare deployments
- Set up dependency chain ensuring linting passes before preview deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull requests now automatically generate preview deployments with live preview URLs.
  * Preview URLs are posted as comments on pull requests and are updated when new commits are pushed.
  * Previewing can be enabled via site configuration (preview URLs turned on).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->